### PR TITLE
README.md: use 'XDG_RUNTIME_DIR' in Hyprland launch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The native Linux version works with BepInEx 5. BepInEx is a mod loader for games
 
 1. Set Steam launch options:
     - **KDE Plasma (and rest):** `./run_bepinex.sh %command%`
-    - **Hyprland:** `PRESSURE_VESSEL_FILESYSTEMS_RW=/run/user/1000/hypr ./run_bepinex.sh %command%`
+    - **Hyprland:** `PRESSURE_VESSEL_FILESYSTEMS_RW="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE" ./run_bepinex.sh %command%`
 
 1. Open the game, go to the settings and select the window dance option in the accessibility tab. Have fun!
 


### PR DESCRIPTION
Currently, the native version of the plugin still won't be able to find Hyprland's sockets with the current command listed in the README if the current user's ID isn't 1000 or the XDG_RUNTIME_DIR's isn't located at '/run/user'.
This pull request fixes that by including the XDG_RUNTIME_DIR environment variable according to the Hyprland wiki (https://wiki.hypr.land/IPC/).
HYPRLAND_INSTANCE_SIGNATURE is technically optional but I included it for the sake of the principle of least privilege.