### PR TITLE
feat(linux): add Vulkan rendering mode support

### DIFF
--- a/LinuxWindowDancePlugin/CustomWindowLinux.cs
+++ b/LinuxWindowDancePlugin/CustomWindowLinux.cs
@@ -7,6 +7,11 @@ public class CustomWindowLinux : CustomWindow
     public CustomWindowLinux(int index, WindowChoreographer choreographer, bool transparent) : base(index, choreographer, transparent)
     {
         Native.SetWindowTextureSize(Window.WindowPtr, renderTexture.width, renderTexture.height);
+
+        if (VulkanTextureBridge.IsSupported)
+        {
+            VulkanTextureBridge.Register(this);
+        }
     }
 
     public override Vector2Int GetPosition()

--- a/LinuxWindowDancePlugin/LinuxWindowDancePlugin.csproj
+++ b/LinuxWindowDancePlugin/LinuxWindowDancePlugin.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <Target Name="FindGameAndIncludeReferences" BeforeTargets="ResolveAssemblyReferences" Condition="'$(_NitroxDiscovery_TaskAssembly)' != ''">
-    <DiscoverGame GameName="Rhythm Doctor">
+    <DiscoverGame GameName="Rhythm Doctor" Condition="'$(GameDir)' == ''">
         <Output TaskParameter="GamePath" PropertyName="GameDir" />
     </DiscoverGame>
     <Error Condition="'$(GameDir)' == ''" Text="Failed to find the game 'Rhythm Doctor' on your machine" />

--- a/LinuxWindowDancePlugin/Native.cs
+++ b/LinuxWindowDancePlugin/Native.cs
@@ -9,6 +9,9 @@ public class Native
     [DllImport("multiwindow_unity", EntryPoint = "set_window_texture_size")]
     public static extern void SetWindowTextureSize(IntPtr window, int w, int h);
 
+    [DllImport("multiwindow_unity", EntryPoint = "set_window_texture_pixels")]
+    public static extern void SetWindowTexturePixels(IntPtr window, byte[] textureBytes, int byteCount, int w, int h);
+
     [DllImport("multiwindow_unity", EntryPoint = "get_monitors")]
     public static extern NativeMonitors GetMonitors();
 

--- a/LinuxWindowDancePlugin/Native.cs
+++ b/LinuxWindowDancePlugin/Native.cs
@@ -6,15 +6,26 @@ namespace LinuxWindowDancePlugin;
 
 public class Native
 {
+    public const int RenderEventVulkanCopy = 1;
+
+    [DllImport("multiwindow_unity", EntryPoint = "set_window_texture")]
+    public static extern IntPtr SetWindowTexture(IntPtr window, IntPtr texturePtr);
+
     [DllImport("multiwindow_unity", EntryPoint = "set_window_texture_size")]
     public static extern void SetWindowTextureSize(IntPtr window, int w, int h);
 
     [DllImport("multiwindow_unity", EntryPoint = "set_window_texture_pixels")]
     public static extern void SetWindowTexturePixels(IntPtr window, byte[] textureBytes, int byteCount, int w, int h);
 
+    [DllImport("multiwindow_unity", EntryPoint = "set_window_texture_pixels")]
+    public static extern void SetWindowTexturePixelsPtr(IntPtr window, IntPtr textureBytes, int byteCount, int w, int h);
+
     [DllImport("multiwindow_unity", EntryPoint = "get_monitors")]
     public static extern NativeMonitors GetMonitors();
 
     [DllImport("multiwindow_unity", EntryPoint = "get_info")]
     public static extern string GetInfo();
+
+    [DllImport("multiwindow_unity", EntryPoint = "get_render_event_func")]
+    public static extern IntPtr GetRenderEventFunc();
 }

--- a/LinuxWindowDancePlugin/Plugin.cs
+++ b/LinuxWindowDancePlugin/Plugin.cs
@@ -42,7 +42,7 @@ public class Plugin : BaseUnityPlugin
         Logger.LogInfo($"Graphics device type: {UnityEngine.SystemInfo.graphicsDeviceType}");
         if (VulkanTextureBridge.IsSupported)
         {
-            Logger.LogInfo("Vulkan detected; custom windows will use CPU readback compatibility mode.");
+            Logger.LogInfo("Vulkan detected; custom windows will use native texture registration + plugin events.");
         }
 
         Logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} is loaded!");

--- a/LinuxWindowDancePlugin/Plugin.cs
+++ b/LinuxWindowDancePlugin/Plugin.cs
@@ -9,15 +9,41 @@ namespace LinuxWindowDancePlugin;
 public class Plugin : BaseUnityPlugin
 {
     internal static new ManualLogSource Logger;
+    internal static bool DebugLoggingEnabled;
+
+    private static bool ReadDebugFlag()
+    {
+        string value = Environment.GetEnvironmentVariable("RD_DANCE_DEBUG") ?? string.Empty;
+        value = value.Trim().ToLowerInvariant();
+        return value.Length > 0 && value != "0" && value != "false" && value != "off" && value != "no";
+    }
+
+    internal static void LogDebug(string message)
+    {
+        if (DebugLoggingEnabled)
+        {
+            Logger.LogInfo($"[Debug] {message}");
+        }
+    }
 
     private void Awake()
     {
         // Plugin startup logic
         Logger = base.Logger;
+        DebugLoggingEnabled = ReadDebugFlag();
 
         MultiWindow.Interop.NativeMethods.GetMainWindow(); // Just to load the plugin
 
+        VulkanTextureBridge.EnsureCreated();
+
         Harmony.CreateAndPatchAll(typeof(Patches));
+
+        Logger.LogInfo($"RD_DANCE_DEBUG={DebugLoggingEnabled}");
+        Logger.LogInfo($"Graphics device type: {UnityEngine.SystemInfo.graphicsDeviceType}");
+        if (VulkanTextureBridge.IsSupported)
+        {
+            Logger.LogInfo("Vulkan detected; custom windows will use CPU readback compatibility mode.");
+        }
 
         Logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} is loaded!");
     }

--- a/LinuxWindowDancePlugin/VulkanTextureBridge.cs
+++ b/LinuxWindowDancePlugin/VulkanTextureBridge.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Unity.Collections;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace LinuxWindowDancePlugin;
+
+public sealed class VulkanTextureBridge : MonoBehaviour
+{
+    private sealed class TrackedWindow
+    {
+        public CustomWindowLinux Window = null!;
+        public Texture2D? StagingTexture;
+        public int CaptureCount;
+        public bool LoggedMissingSourceTexture;
+        public bool LoggedMissingWindowPtr;
+        public bool LoggedFirstSuccessfulUpload;
+    }
+
+    private static VulkanTextureBridge? instance;
+    private readonly List<TrackedWindow> trackedWindows = new();
+    private readonly WaitForEndOfFrame endOfFrame = new();
+
+    public static bool IsSupported => SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan;
+
+    public static void EnsureCreated()
+    {
+        if (!IsSupported || instance != null)
+        {
+            return;
+        }
+
+        Plugin.LogDebug("Creating VulkanTextureBridge helper GameObject.");
+        GameObject gameObject = new("LinuxWindowDancePlugin.VulkanTextureBridge");
+        gameObject.hideFlags = HideFlags.HideAndDontSave;
+        DontDestroyOnLoad(gameObject);
+        instance = gameObject.AddComponent<VulkanTextureBridge>();
+    }
+
+    public static void Register(CustomWindowLinux window)
+    {
+        if (!IsSupported || window == null)
+        {
+            return;
+        }
+
+        EnsureCreated();
+        instance?.RegisterInternal(window);
+    }
+
+    private void Awake()
+    {
+        if (instance != null && instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        instance = this;
+        DontDestroyOnLoad(gameObject);
+        Plugin.LogDebug("VulkanTextureBridge Awake -> starting capture loop.");
+        StartCoroutine(CaptureLoop());
+    }
+
+    private void RegisterInternal(CustomWindowLinux window)
+    {
+        foreach (TrackedWindow trackedWindow in trackedWindows)
+        {
+            if (ReferenceEquals(trackedWindow.Window, window))
+            {
+                Plugin.LogDebug($"Skip duplicate Vulkan window registration: ptr=0x{window.Window.WindowPtr.ToInt64():X}");
+                return;
+            }
+        }
+
+        Plugin.Logger.LogInfo(
+            $"Register Vulkan window: ptr=0x{window.Window.WindowPtr.ToInt64():X}, rt={(window.renderTexture != null ? window.renderTexture.width + "x" + window.renderTexture.height : "null")}");
+        trackedWindows.Add(new TrackedWindow { Window = window });
+    }
+
+    private IEnumerator CaptureLoop()
+    {
+        while (true)
+        {
+            yield return endOfFrame;
+
+            for (int i = trackedWindows.Count - 1; i >= 0; i--)
+            {
+                try
+                {
+                    if (!CaptureWindow(trackedWindows[i]))
+                    {
+                        trackedWindows.RemoveAt(i);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Plugin.Logger.LogWarning($"Vulkan texture capture failed: {ex}");
+                }
+            }
+        }
+    }
+
+    private static Texture2D EnsureStagingTexture(TrackedWindow trackedWindow, int width, int height)
+    {
+        if (trackedWindow.StagingTexture != null && trackedWindow.StagingTexture.width == width && trackedWindow.StagingTexture.height == height)
+        {
+            return trackedWindow.StagingTexture;
+        }
+
+        if (trackedWindow.StagingTexture != null)
+        {
+            Destroy(trackedWindow.StagingTexture);
+        }
+
+        trackedWindow.StagingTexture = new Texture2D(width, height, TextureFormat.RGBA32, false, false)
+        {
+            filterMode = FilterMode.Point,
+            wrapMode = TextureWrapMode.Clamp,
+            name = $"VulkanWindowBridge_{width}x{height}"
+        };
+
+        Plugin.Logger.LogInfo($"Create Vulkan staging texture: {width}x{height}");
+        Native.SetWindowTextureSize(trackedWindow.Window.Window.WindowPtr, width, height);
+        return trackedWindow.StagingTexture;
+    }
+
+    private static string DescribeSample(byte[] rawData, int width, int height)
+    {
+        if (rawData.Length < 4 || width <= 0 || height <= 0)
+        {
+            return "sample=unavailable";
+        }
+
+        static string PixelAt(byte[] data, int widthValue, int heightValue, int x, int y)
+        {
+            x = Mathf.Clamp(x, 0, widthValue - 1);
+            y = Mathf.Clamp(y, 0, heightValue - 1);
+            int index = (y * widthValue + x) * 4;
+            if (index + 3 >= data.Length)
+            {
+                return "(out-of-range)";
+            }
+
+            return $"({data[index + 0]},{data[index + 1]},{data[index + 2]},{data[index + 3]})";
+        }
+
+        return $"tl={PixelAt(rawData, width, height, 0, 0)} center={PixelAt(rawData, width, height, width / 2, height / 2)} br={PixelAt(rawData, width, height, width - 1, height - 1)}";
+    }
+
+    private static bool CaptureWindow(TrackedWindow trackedWindow)
+    {
+        if (trackedWindow.Window == null || trackedWindow.Window.Window == null)
+        {
+            Plugin.Logger.LogWarning("Vulkan capture stopped because target window reference is gone.");
+            return false;
+        }
+
+        RenderTexture sourceTexture = trackedWindow.Window.renderTexture;
+        if (sourceTexture == null)
+        {
+            if (!trackedWindow.LoggedMissingSourceTexture)
+            {
+                Plugin.Logger.LogWarning($"Vulkan capture waiting for RenderTexture: ptr=0x{trackedWindow.Window.Window.WindowPtr.ToInt64():X}");
+                trackedWindow.LoggedMissingSourceTexture = true;
+            }
+            return true;
+        }
+        trackedWindow.LoggedMissingSourceTexture = false;
+
+        IntPtr windowPtr = trackedWindow.Window.Window.WindowPtr;
+        if (windowPtr == IntPtr.Zero)
+        {
+            if (!trackedWindow.LoggedMissingWindowPtr)
+            {
+                Plugin.Logger.LogWarning("Vulkan capture waiting for native window pointer (still zero).");
+                trackedWindow.LoggedMissingWindowPtr = true;
+            }
+            return true;
+        }
+        trackedWindow.LoggedMissingWindowPtr = false;
+
+        Texture2D stagingTexture = EnsureStagingTexture(trackedWindow, sourceTexture.width, sourceTexture.height);
+        RenderTexture previousRenderTexture = RenderTexture.active;
+
+        if (Plugin.DebugLoggingEnabled && (trackedWindow.CaptureCount < 3 || trackedWindow.CaptureCount % 120 == 0))
+        {
+            Plugin.LogDebug(
+                $"CaptureWindow begin: ptr=0x{windowPtr.ToInt64():X}, rt={sourceTexture.width}x{sourceTexture.height}, created={sourceTexture.IsCreated()}, format={sourceTexture.format}, graphicsFormat={sourceTexture.graphicsFormat}");
+        }
+
+        try
+        {
+            RenderTexture.active = sourceTexture;
+            stagingTexture.ReadPixels(new Rect(0, 0, sourceTexture.width, sourceTexture.height), 0, 0, false);
+            stagingTexture.Apply(false, false);
+        }
+        finally
+        {
+            RenderTexture.active = previousRenderTexture;
+        }
+
+        NativeArray<byte> rawDataView = stagingTexture.GetRawTextureData<byte>();
+        byte[] rawData = rawDataView.ToArray();
+        Native.SetWindowTexturePixels(windowPtr, rawData, rawData.Length, sourceTexture.width, sourceTexture.height);
+
+        if (!trackedWindow.LoggedFirstSuccessfulUpload ||
+            (Plugin.DebugLoggingEnabled && (trackedWindow.CaptureCount < 3 || trackedWindow.CaptureCount % 120 == 0)))
+        {
+            Plugin.Logger.LogInfo(
+                $"Vulkan upload frame {trackedWindow.CaptureCount} -> ptr=0x{windowPtr.ToInt64():X}, bytes={rawData.Length}, {DescribeSample(rawData, sourceTexture.width, sourceTexture.height)}");
+            trackedWindow.LoggedFirstSuccessfulUpload = true;
+        }
+
+        trackedWindow.CaptureCount++;
+        return true;
+    }
+}

--- a/LinuxWindowDancePlugin/VulkanTextureBridge.cs
+++ b/LinuxWindowDancePlugin/VulkanTextureBridge.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using Unity.Collections;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -12,11 +11,13 @@ public sealed class VulkanTextureBridge : MonoBehaviour
     private sealed class TrackedWindow
     {
         public CustomWindowLinux Window = null!;
-        public Texture2D? StagingTexture;
-        public int CaptureCount;
         public bool LoggedMissingSourceTexture;
         public bool LoggedMissingWindowPtr;
-        public bool LoggedFirstSuccessfulUpload;
+        public bool LoggedMissingNativeTexture;
+        public bool LoggedRegisteredTexture;
+        public int NativeTextureWidth = -1;
+        public int NativeTextureHeight = -1;
+        public IntPtr NativeTexturePtr = IntPtr.Zero;
     }
 
     private static VulkanTextureBridge? instance;
@@ -60,8 +61,8 @@ public sealed class VulkanTextureBridge : MonoBehaviour
 
         instance = this;
         DontDestroyOnLoad(gameObject);
-        Plugin.LogDebug("VulkanTextureBridge Awake -> starting capture loop.");
-        StartCoroutine(CaptureLoop());
+        Plugin.Logger.LogInfo("VulkanTextureBridge Awake -> using native Vulkan texture registration + plugin events.");
+        StartCoroutine(RenderLoop());
     }
 
     private void RegisterInternal(CustomWindowLinux window)
@@ -80,81 +81,53 @@ public sealed class VulkanTextureBridge : MonoBehaviour
         trackedWindows.Add(new TrackedWindow { Window = window });
     }
 
-    private IEnumerator CaptureLoop()
+    private IEnumerator RenderLoop()
     {
         while (true)
         {
             yield return endOfFrame;
 
+            bool issuedAnyVulkanWork = false;
+
             for (int i = trackedWindows.Count - 1; i >= 0; i--)
             {
                 try
                 {
-                    if (!CaptureWindow(trackedWindows[i]))
+                    if (!UpdateWindowRegistration(trackedWindows[i], ref issuedAnyVulkanWork))
                     {
                         trackedWindows.RemoveAt(i);
                     }
                 }
                 catch (Exception ex)
                 {
-                    Plugin.Logger.LogWarning($"Vulkan texture capture failed: {ex}");
+                    Plugin.Logger.LogWarning($"Vulkan texture bridge update failed: {ex}");
                 }
             }
-        }
-    }
 
-    private static Texture2D EnsureStagingTexture(TrackedWindow trackedWindow, int width, int height)
-    {
-        if (trackedWindow.StagingTexture != null && trackedWindow.StagingTexture.width == width && trackedWindow.StagingTexture.height == height)
-        {
-            return trackedWindow.StagingTexture;
-        }
-
-        if (trackedWindow.StagingTexture != null)
-        {
-            Destroy(trackedWindow.StagingTexture);
-        }
-
-        trackedWindow.StagingTexture = new Texture2D(width, height, TextureFormat.RGBA32, false, false)
-        {
-            filterMode = FilterMode.Point,
-            wrapMode = TextureWrapMode.Clamp,
-            name = $"VulkanWindowBridge_{width}x{height}"
-        };
-
-        Plugin.Logger.LogInfo($"Create Vulkan staging texture: {width}x{height}");
-        Native.SetWindowTextureSize(trackedWindow.Window.Window.WindowPtr, width, height);
-        return trackedWindow.StagingTexture;
-    }
-
-    private static string DescribeSample(byte[] rawData, int width, int height)
-    {
-        if (rawData.Length < 4 || width <= 0 || height <= 0)
-        {
-            return "sample=unavailable";
-        }
-
-        static string PixelAt(byte[] data, int widthValue, int heightValue, int x, int y)
-        {
-            x = Mathf.Clamp(x, 0, widthValue - 1);
-            y = Mathf.Clamp(y, 0, heightValue - 1);
-            int index = (y * widthValue + x) * 4;
-            if (index + 3 >= data.Length)
+            if (issuedAnyVulkanWork)
             {
-                return "(out-of-range)";
+                GL.IssuePluginEvent(Native.GetRenderEventFunc(), Native.RenderEventVulkanCopy);
             }
-
-            return $"({data[index + 0]},{data[index + 1]},{data[index + 2]},{data[index + 3]})";
         }
-
-        return $"tl={PixelAt(rawData, width, height, 0, 0)} center={PixelAt(rawData, width, height, width / 2, height / 2)} br={PixelAt(rawData, width, height, width - 1, height - 1)}";
     }
 
-    private static bool CaptureWindow(TrackedWindow trackedWindow)
+    private static void EnsureNativeTextureSize(TrackedWindow trackedWindow, IntPtr windowPtr, int width, int height)
+    {
+        if (trackedWindow.NativeTextureWidth == width && trackedWindow.NativeTextureHeight == height)
+        {
+            return;
+        }
+
+        Native.SetWindowTextureSize(windowPtr, width, height);
+        trackedWindow.NativeTextureWidth = width;
+        trackedWindow.NativeTextureHeight = height;
+    }
+
+    private static bool UpdateWindowRegistration(TrackedWindow trackedWindow, ref bool issuedAnyVulkanWork)
     {
         if (trackedWindow.Window == null || trackedWindow.Window.Window == null)
         {
-            Plugin.Logger.LogWarning("Vulkan capture stopped because target window reference is gone.");
+            Plugin.Logger.LogWarning("Vulkan bridge stopped because target window reference is gone.");
             return false;
         }
 
@@ -163,7 +136,7 @@ public sealed class VulkanTextureBridge : MonoBehaviour
         {
             if (!trackedWindow.LoggedMissingSourceTexture)
             {
-                Plugin.Logger.LogWarning($"Vulkan capture waiting for RenderTexture: ptr=0x{trackedWindow.Window.Window.WindowPtr.ToInt64():X}");
+                Plugin.Logger.LogWarning($"Vulkan bridge waiting for RenderTexture: ptr=0x{trackedWindow.Window.Window.WindowPtr.ToInt64():X}");
                 trackedWindow.LoggedMissingSourceTexture = true;
             }
             return true;
@@ -175,46 +148,49 @@ public sealed class VulkanTextureBridge : MonoBehaviour
         {
             if (!trackedWindow.LoggedMissingWindowPtr)
             {
-                Plugin.Logger.LogWarning("Vulkan capture waiting for native window pointer (still zero).");
+                Plugin.Logger.LogWarning("Vulkan bridge waiting for native window pointer (still zero).");
                 trackedWindow.LoggedMissingWindowPtr = true;
             }
             return true;
         }
         trackedWindow.LoggedMissingWindowPtr = false;
 
-        Texture2D stagingTexture = EnsureStagingTexture(trackedWindow, sourceTexture.width, sourceTexture.height);
-        RenderTexture previousRenderTexture = RenderTexture.active;
+        if (sourceTexture.width <= 0 || sourceTexture.height <= 0 || !sourceTexture.IsCreated())
+        {
+            return true;
+        }
 
-        if (Plugin.DebugLoggingEnabled && (trackedWindow.CaptureCount < 3 || trackedWindow.CaptureCount % 120 == 0))
+        EnsureNativeTextureSize(trackedWindow, windowPtr, sourceTexture.width, sourceTexture.height);
+
+        IntPtr nativeTexturePtr = sourceTexture.GetNativeTexturePtr();
+        if (nativeTexturePtr == IntPtr.Zero)
+        {
+            if (!trackedWindow.LoggedMissingNativeTexture)
+            {
+                Plugin.Logger.LogWarning($"Vulkan bridge waiting for native texture pointer: ptr=0x{windowPtr.ToInt64():X}");
+                trackedWindow.LoggedMissingNativeTexture = true;
+            }
+            return true;
+        }
+        trackedWindow.LoggedMissingNativeTexture = false;
+
+        if (trackedWindow.NativeTexturePtr != nativeTexturePtr)
+        {
+            Native.SetWindowTexture(windowPtr, nativeTexturePtr);
+            trackedWindow.NativeTexturePtr = nativeTexturePtr;
+
+            Plugin.Logger.LogInfo(
+                $"Registered Vulkan texture: window=0x{windowPtr.ToInt64():X}, texture=0x{nativeTexturePtr.ToInt64():X}, size={sourceTexture.width}x{sourceTexture.height}");
+            trackedWindow.LoggedRegisteredTexture = true;
+        }
+
+        if (Plugin.DebugLoggingEnabled && trackedWindow.LoggedRegisteredTexture)
         {
             Plugin.LogDebug(
-                $"CaptureWindow begin: ptr=0x{windowPtr.ToInt64():X}, rt={sourceTexture.width}x{sourceTexture.height}, created={sourceTexture.IsCreated()}, format={sourceTexture.format}, graphicsFormat={sourceTexture.graphicsFormat}");
+                $"Queued Vulkan plugin event: window=0x{windowPtr.ToInt64():X}, texture=0x{nativeTexturePtr.ToInt64():X}, size={sourceTexture.width}x{sourceTexture.height}, format={sourceTexture.graphicsFormat}");
         }
 
-        try
-        {
-            RenderTexture.active = sourceTexture;
-            stagingTexture.ReadPixels(new Rect(0, 0, sourceTexture.width, sourceTexture.height), 0, 0, false);
-            stagingTexture.Apply(false, false);
-        }
-        finally
-        {
-            RenderTexture.active = previousRenderTexture;
-        }
-
-        NativeArray<byte> rawDataView = stagingTexture.GetRawTextureData<byte>();
-        byte[] rawData = rawDataView.ToArray();
-        Native.SetWindowTexturePixels(windowPtr, rawData, rawData.Length, sourceTexture.width, sourceTexture.height);
-
-        if (!trackedWindow.LoggedFirstSuccessfulUpload ||
-            (Plugin.DebugLoggingEnabled && (trackedWindow.CaptureCount < 3 || trackedWindow.CaptureCount % 120 == 0)))
-        {
-            Plugin.Logger.LogInfo(
-                $"Vulkan upload frame {trackedWindow.CaptureCount} -> ptr=0x{windowPtr.ToInt64():X}, bytes={rawData.Length}, {DescribeSample(rawData, sourceTexture.width, sourceTexture.height)}");
-            trackedWindow.LoggedFirstSuccessfulUpload = true;
-        }
-
-        trackedWindow.CaptureCount++;
+        issuedAnyVulkanWork = true;
         return true;
     }
 }

--- a/LinuxWindowDancePlugin/VulkanTextureBridge.cs
+++ b/LinuxWindowDancePlugin/VulkanTextureBridge.cs
@@ -10,7 +10,7 @@ public sealed class VulkanTextureBridge : MonoBehaviour
 {
     private sealed class TrackedWindow
     {
-        public CustomWindowLinux Window = null!;
+        public CustomWindowLinux Window = null;
         public bool LoggedMissingSourceTexture;
         public bool LoggedMissingWindowPtr;
         public bool LoggedMissingNativeTexture;
@@ -20,9 +20,52 @@ public sealed class VulkanTextureBridge : MonoBehaviour
         public IntPtr NativeTexturePtr = IntPtr.Zero;
     }
 
-    private static VulkanTextureBridge? instance;
+    private static VulkanTextureBridge instance;
     private readonly List<TrackedWindow> trackedWindows = new();
     private readonly WaitForEndOfFrame endOfFrame = new();
+    private static readonly System.Reflection.BindingFlags VisibleMemberFlags =
+        System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic;
+    private static System.Reflection.PropertyInfo cachedVisibleProperty;
+    private static System.Reflection.FieldInfo cachedVisibleField;
+    private static bool resolvedVisibleMember;
+
+    private static bool ShouldIssueVulkanWork(TrackedWindow trackedWindow)
+    {
+        return trackedWindow.Window != null && IsTrackedWindowVisible(trackedWindow.Window);
+    }
+
+    private static bool IsTrackedWindowVisible(CustomWindowLinux window)
+    {
+        if (window == null)
+        {
+            return false;
+        }
+
+        if (!resolvedVisibleMember)
+        {
+            Type windowType = window.GetType();
+            cachedVisibleProperty = windowType.GetProperty("visible", VisibleMemberFlags);
+            cachedVisibleField = windowType.GetField("visible", VisibleMemberFlags);
+            resolvedVisibleMember = true;
+
+            if (cachedVisibleProperty == null && cachedVisibleField == null)
+            {
+                Plugin.LogDebug("VulkanTextureBridge could not resolve a visible member on CustomWindowLinux; falling back to processing registered windows.");
+            }
+        }
+
+        if (cachedVisibleProperty != null && cachedVisibleProperty.PropertyType == typeof(bool))
+        {
+            return (bool)cachedVisibleProperty.GetValue(window);
+        }
+
+        if (cachedVisibleField != null && cachedVisibleField.FieldType == typeof(bool))
+        {
+            return (bool)cachedVisibleField.GetValue(window);
+        }
+
+        return true;
+    }
 
     public static bool IsSupported => SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan;
 
@@ -129,6 +172,11 @@ public sealed class VulkanTextureBridge : MonoBehaviour
         {
             Plugin.Logger.LogWarning("Vulkan bridge stopped because target window reference is gone.");
             return false;
+        }
+
+        if (!ShouldIssueVulkanWork(trackedWindow))
+        {
+            return true;
         }
 
         RenderTexture sourceTexture = trackedWindow.Window.renderTexture;

--- a/build.sh
+++ b/build.sh
@@ -24,10 +24,11 @@ elif [ -f "$1/Rhythm Doctor" ]; then
         exit 1
     fi
 
-    if [ -f "LinuxWindowDancePlugin/bin/Debug/netstandard2.1/LinuxWindowDancePlugin.dll" ]; then
-        echo "Local plugin detected, not downloading."
-    else
-        echo "ERROR: Please follow the readme. (you are using the Linux version and trying to build. This will not work for the Steam Runtime)"
+    echo "Building managed BepInEx plugin..."
+    dotnet build LinuxWindowDancePlugin/LinuxWindowDancePlugin.csproj -c Debug -p:GameDir="$1"
+
+    if [ ! -f "LinuxWindowDancePlugin/bin/Debug/netstandard2.1/LinuxWindowDancePlugin.dll" ]; then
+        echo "ERROR: Failed to build LinuxWindowDancePlugin.dll"
         exit 1
     fi
 else
@@ -41,6 +42,9 @@ if [ $IS_WINE -eq 1 ]; then
 else
     g++ -o multiwindow_unity.so -fPIC -shared multiwindow_unity.cpp `pkg-config Qt6Widgets Qt6DBus xcb glew --libs --cflags` -Og $COMPILE_ARGUMENTS
     mv multiwindow_unity.so "$1/Rhythm Doctor_Data/Plugins/multiwindow_unity.so"
+
+    mkdir -p "$1/BepInEx/plugins"
+    cp "LinuxWindowDancePlugin/bin/Debug/netstandard2.1/LinuxWindowDancePlugin.dll" "$1/BepInEx/plugins/LinuxWindowDancePlugin.dll"
 fi
 
 echo "Finished"

--- a/build.sh
+++ b/build.sh
@@ -24,10 +24,10 @@ elif [ -f "$1/Rhythm Doctor" ]; then
         exit 1
     fi
 
-    echo "Building managed BepInEx plugin..."
-    dotnet build LinuxWindowDancePlugin/LinuxWindowDancePlugin.csproj -c Debug -p:GameDir="$1"
+    echo "Building managed BepInEx plugin (Release)..."
+    dotnet build LinuxWindowDancePlugin/LinuxWindowDancePlugin.csproj -c Release -p:GameDir="$1"
 
-    if [ ! -f "LinuxWindowDancePlugin/bin/Debug/netstandard2.1/LinuxWindowDancePlugin.dll" ]; then
+    if [ ! -f "LinuxWindowDancePlugin/bin/Release/netstandard2.1/LinuxWindowDancePlugin.dll" ]; then
         echo "ERROR: Failed to build LinuxWindowDancePlugin.dll"
         exit 1
     fi
@@ -40,11 +40,11 @@ if [ $IS_WINE -eq 1 ]; then
     wineg++ -o multiwindow_unity.dll -shared multiwindow_unity.cpp multiwindow_unity.dll.spec `pkg-config Qt6Widgets Qt6DBus xcb --libs --cflags` -ld3d11 -O3 $COMPILE_ARGUMENTS
     mv multiwindow_unity.dll.so "$1/Rhythm Doctor_Data/Plugins/x86_64/multiwindow_unity.dll"
 else
-    g++ -o multiwindow_unity.so -fPIC -shared multiwindow_unity.cpp `pkg-config Qt6Widgets Qt6DBus xcb glew --libs --cflags` -Og $COMPILE_ARGUMENTS
+    g++ -o multiwindow_unity.so -fPIC -shared multiwindow_unity.cpp `pkg-config Qt6Widgets Qt6DBus xcb glew --libs --cflags` -O3 -DNDEBUG $COMPILE_ARGUMENTS
     mv multiwindow_unity.so "$1/Rhythm Doctor_Data/Plugins/multiwindow_unity.so"
 
     mkdir -p "$1/BepInEx/plugins"
-    cp "LinuxWindowDancePlugin/bin/Debug/netstandard2.1/LinuxWindowDancePlugin.dll" "$1/BepInEx/plugins/LinuxWindowDancePlugin.dll"
+    cp "LinuxWindowDancePlugin/bin/Release/netstandard2.1/LinuxWindowDancePlugin.dll" "$1/BepInEx/plugins/LinuxWindowDancePlugin.dll"
 fi
 
 echo "Finished"

--- a/multiwindow_unity.cpp
+++ b/multiwindow_unity.cpp
@@ -202,6 +202,15 @@ static inline void requestWindowUpdate(CustomWindow* customWindow) {
     QMetaObject::invokeMethod(customWindow, qOverload<>(&QWidget::update), Qt::QueuedConnection);
 }
 
+static inline bool shouldProcessTextureFrame(CustomWindow* customWindow) {
+    if (customWindow == nullptr) {
+        return false;
+    }
+
+    return !customWindow->isClosing && customWindow->isVisible && customWindow->targetOpacity > 0 &&
+           customWindow->targetWidth > 0 && customWindow->targetHeight > 0 && customWindow->qtImage != nullptr;
+}
+
 #ifndef WITH_WINE
 static void loadVulkanFunctions(const UnityVulkanInstance& instance) {
     auto getProc = [&](const char* name) -> PFN_vkVoidFunction {
@@ -2122,6 +2131,10 @@ static void UNITY_INTERFACE_API render(int eventID) {
     }
 #endif
     for (auto customWindow : allCustomWindows) {
+        if (!shouldProcessTextureFrame(customWindow)) {
+            continue;
+        }
+
         if (customWindow->textureUsesOpenGL) {
             if (customWindow->copyTexture()) {
                 requestWindowUpdate(customWindow);

--- a/multiwindow_unity.cpp
+++ b/multiwindow_unity.cpp
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <iostream>
 typedef void* HANDLE;
 typedef void* HWND;
@@ -30,6 +31,8 @@ typedef bool BOOL;
 typedef char* LPSTR;
 #define WINAPI
 #include "unity/IUnityGraphics.h"
+#define VK_NO_PROTOTYPES
+#include "unity/IUnityGraphicsVulkan.h"
 #include <GL/glew.h>
 #include <QtCore/QtCore>
 #include <QtGui/QPainter>
@@ -107,6 +110,22 @@ static IUnityInterfaces* s_UnityInterfaces = NULL;
 static IUnityGraphics* s_Graphics = NULL;
 static UnityGfxRenderer s_RendererType = kUnityGfxRendererNull;
 static bool s_DebugLoggingEnabled = false;
+#ifndef WITH_WINE
+static IUnityGraphicsVulkan* s_GraphicsVulkan = NULL;
+static PFN_vkGetPhysicalDeviceMemoryProperties s_vkGetPhysicalDeviceMemoryProperties = nullptr;
+static PFN_vkCreateBuffer s_vkCreateBuffer = nullptr;
+static PFN_vkDestroyBuffer s_vkDestroyBuffer = nullptr;
+static PFN_vkGetBufferMemoryRequirements s_vkGetBufferMemoryRequirements = nullptr;
+static PFN_vkAllocateMemory s_vkAllocateMemory = nullptr;
+static PFN_vkFreeMemory s_vkFreeMemory = nullptr;
+static PFN_vkBindBufferMemory s_vkBindBufferMemory = nullptr;
+static PFN_vkMapMemory s_vkMapMemory = nullptr;
+static PFN_vkUnmapMemory s_vkUnmapMemory = nullptr;
+static PFN_vkInvalidateMappedMemoryRanges s_vkInvalidateMappedMemoryRanges = nullptr;
+static PFN_vkCmdCopyImageToBuffer s_vkCmdCopyImageToBuffer = nullptr;
+static PFN_vkCmdPipelineBarrier s_vkCmdPipelineBarrier = nullptr;
+static constexpr int kRenderEventVulkanCopy = 1;
+#endif
 
 xcb_connection_t* globalXcbConnection;
 Hyprctl* hyprctl = nullptr;
@@ -164,6 +183,337 @@ char* createString(const char* string) {
     return address;
 #endif
 }
+
+static inline void requestWindowUpdate(CustomWindow* customWindow) {
+    if (customWindow == nullptr) {
+        return;
+    }
+
+    if (customWindow->isClosing || !customWindow->isVisible || customWindow->targetOpacity <= 0 ||
+        customWindow->targetWidth <= 0 || customWindow->targetHeight <= 0 || customWindow->qtImage == nullptr) {
+        return;
+    }
+
+    bool updateWasAlreadyQueued = customWindow->updateQueued.exchange(true, std::memory_order_acq_rel);
+    if (updateWasAlreadyQueued) {
+        return;
+    }
+
+    QMetaObject::invokeMethod(customWindow, qOverload<>(&QWidget::update), Qt::QueuedConnection);
+}
+
+#ifndef WITH_WINE
+static void loadVulkanFunctions(const UnityVulkanInstance& instance) {
+    auto getProc = [&](const char* name) -> PFN_vkVoidFunction {
+        if (instance.getInstanceProcAddr == nullptr) {
+            return nullptr;
+        }
+        return instance.getInstanceProcAddr(instance.instance, name);
+    };
+
+    s_vkGetPhysicalDeviceMemoryProperties =
+        (PFN_vkGetPhysicalDeviceMemoryProperties)getProc("vkGetPhysicalDeviceMemoryProperties");
+    s_vkCreateBuffer = (PFN_vkCreateBuffer)getProc("vkCreateBuffer");
+    s_vkDestroyBuffer = (PFN_vkDestroyBuffer)getProc("vkDestroyBuffer");
+    s_vkGetBufferMemoryRequirements = (PFN_vkGetBufferMemoryRequirements)getProc("vkGetBufferMemoryRequirements");
+    s_vkAllocateMemory = (PFN_vkAllocateMemory)getProc("vkAllocateMemory");
+    s_vkFreeMemory = (PFN_vkFreeMemory)getProc("vkFreeMemory");
+    s_vkBindBufferMemory = (PFN_vkBindBufferMemory)getProc("vkBindBufferMemory");
+    s_vkMapMemory = (PFN_vkMapMemory)getProc("vkMapMemory");
+    s_vkUnmapMemory = (PFN_vkUnmapMemory)getProc("vkUnmapMemory");
+    s_vkInvalidateMappedMemoryRanges = (PFN_vkInvalidateMappedMemoryRanges)getProc("vkInvalidateMappedMemoryRanges");
+    s_vkCmdCopyImageToBuffer = (PFN_vkCmdCopyImageToBuffer)getProc("vkCmdCopyImageToBuffer");
+    s_vkCmdPipelineBarrier = (PFN_vkCmdPipelineBarrier)getProc("vkCmdPipelineBarrier");
+}
+
+static uint32_t findVulkanMemoryType(uint32_t typeBits, VkMemoryPropertyFlags propertyFlags) {
+    if (s_GraphicsVulkan == nullptr || s_vkGetPhysicalDeviceMemoryProperties == nullptr) {
+        return UINT32_MAX;
+    }
+
+    UnityVulkanInstance instance = s_GraphicsVulkan->Instance();
+    VkPhysicalDeviceMemoryProperties memoryProperties = {};
+    s_vkGetPhysicalDeviceMemoryProperties(instance.physicalDevice, &memoryProperties);
+    for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; ++i) {
+        if ((typeBits & (1u << i)) == 0) {
+            continue;
+        }
+        if ((memoryProperties.memoryTypes[i].propertyFlags & propertyFlags) == propertyFlags) {
+            return i;
+        }
+    }
+    return UINT32_MAX;
+}
+
+static void releaseVulkanReadbackResources(CustomWindow* customWindow) {
+    if (customWindow == nullptr) {
+        return;
+    }
+
+    if (s_GraphicsVulkan != nullptr) {
+        UnityVulkanInstance instance = s_GraphicsVulkan->Instance();
+        if (instance.device != VK_NULL_HANDLE) {
+            VkDeviceMemory memory = (VkDeviceMemory)customWindow->vulkanReadbackMemory;
+            VkBuffer buffer = (VkBuffer)customWindow->vulkanReadbackBuffer;
+            if (memory != VK_NULL_HANDLE && customWindow->vulkanReadbackMapped != nullptr && s_vkUnmapMemory != nullptr) {
+                s_vkUnmapMemory(instance.device, memory);
+            }
+            if (buffer != VK_NULL_HANDLE && s_vkDestroyBuffer != nullptr) {
+                s_vkDestroyBuffer(instance.device, buffer, nullptr);
+            }
+            if (memory != VK_NULL_HANDLE && s_vkFreeMemory != nullptr) {
+                s_vkFreeMemory(instance.device, memory, nullptr);
+            }
+        }
+    }
+
+    customWindow->vulkanReadbackBuffer = nullptr;
+    customWindow->vulkanReadbackMemory = nullptr;
+    customWindow->vulkanReadbackMapped = nullptr;
+    customWindow->vulkanReadbackSize = 0;
+    customWindow->vulkanReadbackHostCoherent = false;
+    customWindow->vulkanReadbackWidth = 0;
+    customWindow->vulkanReadbackHeight = 0;
+    customWindow->vulkanReadbackSwapRedBlue = false;
+    customWindow->vulkanReadbackSubmittedFrame = 0;
+    customWindow->vulkanReadbackPending = false;
+}
+
+static bool ensureVulkanReadbackResources(CustomWindow* customWindow, int width, int height) {
+    if (customWindow == nullptr || s_GraphicsVulkan == nullptr || customWindow->qtImage == nullptr || width <= 0 || height <= 0 ||
+        s_vkCreateBuffer == nullptr || s_vkGetBufferMemoryRequirements == nullptr || s_vkAllocateMemory == nullptr ||
+        s_vkBindBufferMemory == nullptr || s_vkMapMemory == nullptr) {
+        return false;
+    }
+
+    size_t requiredSize = (size_t)width * (size_t)height * 4;
+    if (customWindow->vulkanReadbackBuffer != nullptr && customWindow->vulkanReadbackMapped != nullptr &&
+        customWindow->vulkanReadbackSize == requiredSize && customWindow->vulkanReadbackWidth == width &&
+        customWindow->vulkanReadbackHeight == height) {
+        return true;
+    }
+
+    releaseVulkanReadbackResources(customWindow);
+
+    UnityVulkanInstance instance = s_GraphicsVulkan->Instance();
+    if (instance.device == VK_NULL_HANDLE) {
+        return false;
+    }
+
+    VkBufferCreateInfo bufferCreateInfo = {};
+    bufferCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferCreateInfo.size = requiredSize;
+    bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VkBuffer buffer = VK_NULL_HANDLE;
+    if (s_vkCreateBuffer(instance.device, &bufferCreateInfo, nullptr, &buffer) != VK_SUCCESS) {
+        qWarning() << "[TextureDebug] Failed to create Vulkan readback buffer for window" << customWindow->customId;
+        return false;
+    }
+
+    VkMemoryRequirements requirements = {};
+    s_vkGetBufferMemoryRequirements(instance.device, buffer, &requirements);
+
+    VkMemoryPropertyFlags preferredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    uint32_t memoryTypeIndex = findVulkanMemoryType(requirements.memoryTypeBits, preferredFlags);
+    bool hostCoherent = true;
+    if (memoryTypeIndex == UINT32_MAX) {
+        preferredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+        hostCoherent = false;
+        memoryTypeIndex = findVulkanMemoryType(requirements.memoryTypeBits, preferredFlags);
+    }
+    if (memoryTypeIndex == UINT32_MAX) {
+        qWarning() << "[TextureDebug] Failed to find Vulkan host-visible memory type for window" << customWindow->customId;
+        if (s_vkDestroyBuffer != nullptr) {
+            s_vkDestroyBuffer(instance.device, buffer, nullptr);
+        }
+        return false;
+    }
+
+    VkMemoryAllocateInfo allocateInfo = {};
+    allocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    allocateInfo.allocationSize = requirements.size;
+    allocateInfo.memoryTypeIndex = memoryTypeIndex;
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    if (s_vkAllocateMemory(instance.device, &allocateInfo, nullptr, &memory) != VK_SUCCESS) {
+        qWarning() << "[TextureDebug] Failed to allocate Vulkan readback memory for window" << customWindow->customId;
+        if (s_vkDestroyBuffer != nullptr) {
+            s_vkDestroyBuffer(instance.device, buffer, nullptr);
+        }
+        return false;
+    }
+
+    if (s_vkBindBufferMemory(instance.device, buffer, memory, 0) != VK_SUCCESS) {
+        qWarning() << "[TextureDebug] Failed to bind Vulkan readback memory for window" << customWindow->customId;
+        if (s_vkFreeMemory != nullptr) {
+            s_vkFreeMemory(instance.device, memory, nullptr);
+        }
+        if (s_vkDestroyBuffer != nullptr) {
+            s_vkDestroyBuffer(instance.device, buffer, nullptr);
+        }
+        return false;
+    }
+
+    void* mapped = nullptr;
+    if (s_vkMapMemory(instance.device, memory, 0, requirements.size, 0, &mapped) != VK_SUCCESS || mapped == nullptr) {
+        qWarning() << "[TextureDebug] Failed to map Vulkan readback memory for window" << customWindow->customId;
+        if (s_vkFreeMemory != nullptr) {
+            s_vkFreeMemory(instance.device, memory, nullptr);
+        }
+        if (s_vkDestroyBuffer != nullptr) {
+            s_vkDestroyBuffer(instance.device, buffer, nullptr);
+        }
+        return false;
+    }
+
+    customWindow->vulkanReadbackBuffer = (void*)buffer;
+    customWindow->vulkanReadbackMemory = (void*)memory;
+    customWindow->vulkanReadbackMapped = mapped;
+    customWindow->vulkanReadbackSize = requiredSize;
+    customWindow->vulkanReadbackHostCoherent = hostCoherent;
+    customWindow->vulkanReadbackWidth = width;
+    customWindow->vulkanReadbackHeight = height;
+    customWindow->vulkanReadbackPending = false;
+    return true;
+}
+
+static bool processCompletedVulkanReadback(CustomWindow* customWindow, unsigned long long safeFrameNumber) {
+    if (customWindow == nullptr || !customWindow->textureUsesVulkan || !customWindow->vulkanReadbackPending ||
+        customWindow->qtImage == nullptr || customWindow->vulkanReadbackMapped == nullptr ||
+        safeFrameNumber < customWindow->vulkanReadbackSubmittedFrame) {
+        return false;
+    }
+
+    if (!customWindow->vulkanReadbackHostCoherent && s_GraphicsVulkan != nullptr && s_vkInvalidateMappedMemoryRanges != nullptr) {
+        UnityVulkanInstance instance = s_GraphicsVulkan->Instance();
+        VkMappedMemoryRange mappedRange = {};
+        mappedRange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+        mappedRange.memory = (VkDeviceMemory)customWindow->vulkanReadbackMemory;
+        mappedRange.offset = 0;
+        mappedRange.size = customWindow->vulkanReadbackSize;
+        s_vkInvalidateMappedMemoryRanges(instance.device, 1, &mappedRange);
+    }
+
+    int width = customWindow->qtImage->width();
+    int height = customWindow->qtImage->height();
+    int destinationBytesPerLine = customWindow->qtImage->bytesPerLine();
+    int sourceBytesPerLine = width * 4;
+    uchar* destination = customWindow->qtImage->bits();
+    const uchar* source = (const uchar*)customWindow->vulkanReadbackMapped;
+    bool canMemcpyWithoutSwizzle =
+        !customWindow->vulkanReadbackSwapRedBlue || customWindow->qtImage->format() == QImage::Format_ARGB32;
+
+    if (canMemcpyWithoutSwizzle && destinationBytesPerLine == sourceBytesPerLine) {
+        memcpy(destination, source, (size_t)destinationBytesPerLine * (size_t)height);
+    } else {
+        for (int y = 0; y < height; ++y) {
+            uchar* destinationRow = destination + (size_t)y * (size_t)destinationBytesPerLine;
+            const uchar* sourceRow = source + (size_t)y * (size_t)sourceBytesPerLine;
+            if (canMemcpyWithoutSwizzle) {
+                memcpy(destinationRow, sourceRow, sourceBytesPerLine);
+            } else {
+                for (int x = 0; x < width; ++x) {
+                    destinationRow[x * 4 + 0] = sourceRow[x * 4 + 2];
+                    destinationRow[x * 4 + 1] = sourceRow[x * 4 + 1];
+                    destinationRow[x * 4 + 2] = sourceRow[x * 4 + 0];
+                    destinationRow[x * 4 + 3] = sourceRow[x * 4 + 3];
+                }
+            }
+        }
+    }
+
+    // Unity's Vulkan texture memory reaches us in the same bottom-up orientation
+    // expected by the existing Qt paint path used for OpenGL/CPU copies.
+    // Keep the orientation flag aligned with those paths so paintEvent performs
+    // the vertical flip before presenting into the QWidget.
+    customWindow->textureDataIsUpsideDown = true;
+    customWindow->hasTexturePixels = true;
+    customWindow->vulkanReadbackPending = false;
+    customWindow->debugLoggedMissingTexture = false;
+
+    if (s_DebugLoggingEnabled && (customWindow->debugCopyCount < 3 || customWindow->debugCopyCount % 120 == 0)) {
+        qInfo() << "[TextureDebug] copyTexture(Vulkan) window" << customWindow->customId << "image" << width << "x"
+                << height << samplePixelSummary((const unsigned char*)customWindow->qtImage->constBits(), width, height);
+    }
+    customWindow->debugCopyCount++;
+    return true;
+}
+
+static bool submitVulkanReadback(CustomWindow* customWindow, const UnityVulkanRecordingState& recordingState) {
+    if (customWindow == nullptr || !customWindow->textureUsesVulkan || customWindow->unityVulkanTexture == nullptr ||
+        customWindow->qtImage == nullptr || customWindow->vulkanReadbackPending || s_GraphicsVulkan == nullptr ||
+        s_vkCmdCopyImageToBuffer == nullptr || s_vkCmdPipelineBarrier == nullptr) {
+        return false;
+    }
+
+    UnityVulkanImage unityImage = {};
+    if (!s_GraphicsVulkan->AccessTexture(customWindow->unityVulkanTexture, UnityVulkanWholeImage,
+                                         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                         VK_ACCESS_TRANSFER_READ_BIT, kUnityVulkanResourceAccess_PipelineBarrier,
+                                         &unityImage)) {
+        qWarning() << "[TextureDebug] AccessTexture failed for Vulkan window" << customWindow->customId;
+        return false;
+    }
+
+    int width = (int)unityImage.extent.width;
+    int height = (int)unityImage.extent.height;
+    if (width <= 0 || height <= 0) {
+        return false;
+    }
+
+    customWindow->vulkanReadbackSwapRedBlue =
+        unityImage.format == VK_FORMAT_B8G8R8A8_UNORM || unityImage.format == VK_FORMAT_B8G8R8A8_SRGB;
+
+    if (customWindow->qtImage == nullptr || customWindow->qtImage->width() != width || customWindow->qtImage->height() != height) {
+        customWindow->setTextureSize(width, height);
+    } else if (customWindow->vulkanReadbackSwapRedBlue && customWindow->qtImage->format() != QImage::Format_ARGB32) {
+        customWindow->setTextureSize(width, height);
+    } else if (!customWindow->vulkanReadbackSwapRedBlue && customWindow->qtImage->format() != QImage::Format_RGBA8888) {
+        customWindow->setTextureSize(width, height);
+    }
+
+    if (!ensureVulkanReadbackResources(customWindow, width, height)) {
+        return false;
+    }
+
+    VkBufferImageCopy copyRegion = {};
+    copyRegion.imageSubresource.aspectMask = unityImage.aspect != 0 ? unityImage.aspect : VK_IMAGE_ASPECT_COLOR_BIT;
+    copyRegion.imageSubresource.mipLevel = 0;
+    copyRegion.imageSubresource.baseArrayLayer = 0;
+    copyRegion.imageSubresource.layerCount = 1;
+    copyRegion.imageExtent.width = (uint32_t)width;
+    copyRegion.imageExtent.height = (uint32_t)height;
+    copyRegion.imageExtent.depth = 1;
+
+    s_vkCmdCopyImageToBuffer(recordingState.commandBuffer, unityImage.image, unityImage.layout,
+                             (VkBuffer)customWindow->vulkanReadbackBuffer, 1, &copyRegion);
+
+    VkBufferMemoryBarrier bufferBarrier = {};
+    bufferBarrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+    bufferBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    bufferBarrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+    bufferBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    bufferBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    bufferBarrier.buffer = (VkBuffer)customWindow->vulkanReadbackBuffer;
+    bufferBarrier.offset = 0;
+    bufferBarrier.size = customWindow->vulkanReadbackSize;
+
+    s_vkCmdPipelineBarrier(recordingState.commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_HOST_BIT, 0,
+                           0, nullptr, 1, &bufferBarrier, 0, nullptr);
+
+    customWindow->vulkanReadbackSubmittedFrame = recordingState.currentFrameNumber;
+    customWindow->vulkanReadbackPending = true;
+
+    if (s_DebugLoggingEnabled && (customWindow->debugTextureUpdateCount < 3 || customWindow->debugTextureUpdateCount % 120 == 0)) {
+        qInfo() << "[TextureDebug] submitted Vulkan readback window" << customWindow->customId << "frame"
+                << recordingState.currentFrameNumber << "size" << width << "x" << height;
+    }
+    customWindow->debugTextureUpdateCount++;
+    return true;
+}
+#endif
 
 class CustomApplication : public QApplication {
   public:
@@ -663,10 +1013,14 @@ bool CustomWindow::copyTexture() {
     uchar* startingBits = qtImage->bits();
     uchar* source = (uchar*)mapped.pData;
 
-    for (int i = 0; i < height; i++) {
-        int invertedY = (height - i - 1);
-        memcpy(startingBits + i * bytesPerLine, source + invertedY * bytesPerLine, bytesPerLine);
+    if (mapped.RowPitch == (UINT)bytesPerLine) {
+        memcpy(startingBits, source, bytesPerLine * height);
+    } else {
+        for (int i = 0; i < height; i++) {
+            memcpy(startingBits + i * bytesPerLine, source + i * mapped.RowPitch, bytesPerLine);
+        }
     }
+    this->textureDataIsUpsideDown = true;
 
     ctx->Unmap(stagingTexture, 0);
     ctx->Release();
@@ -678,19 +1032,48 @@ bool CustomWindow::copyTexture() {
 void CustomWindow::setTexture(GLuint textureId) {
     this->glTextureId = textureId;
     this->textureUsesOpenGL = true;
+    this->textureUsesVulkan = false;
     if (s_DebugLoggingEnabled) {
         qInfo() << "[TextureDebug] setTexture(OpenGL) window" << this->customId << "textureId" << textureId;
     }
 }
 
-void CustomWindow::setTextureSize(int w, int h) {
-    SAFE_DELETE(this->qtImage);
-    this->qtImage = new QImage(w, h, QImage::Format_RGBA8888_Premultiplied);
-    SAFE_FREE(this->tempTexture);
-    tempTexture = malloc(w * h * 4);
-    this->hasTexturePixels = false;
+void CustomWindow::setVulkanTexture(void* texturePtr) {
+    this->unityVulkanTexture = texturePtr;
+    this->textureUsesOpenGL = false;
+    this->textureUsesVulkan = texturePtr != nullptr;
+    if (texturePtr == nullptr) {
+        this->hasTexturePixels = false;
+        this->vulkanReadbackPending = false;
+    }
     if (s_DebugLoggingEnabled) {
-        qInfo() << "[TextureDebug] setTextureSize window" << this->customId << "size" << w << "x" << h;
+        qInfo() << "[TextureDebug] setTexture(Vulkan) window" << this->customId << "texturePtr" << texturePtr;
+    }
+}
+
+void CustomWindow::setTextureSize(int w, int h) {
+    if (w <= 0 || h <= 0) {
+        qWarning() << "[TextureDebug] setTextureSize ignored invalid size for window" << this->customId << w << h;
+        return;
+    }
+
+    QImage::Format desiredFormat =
+        this->textureUsesVulkan && this->vulkanReadbackSwapRedBlue ? QImage::Format_ARGB32 : QImage::Format_RGBA8888;
+
+    if (this->qtImage != nullptr && this->qtImage->width() == w && this->qtImage->height() == h &&
+        this->qtImage->format() == desiredFormat) {
+        return;
+    }
+
+    SAFE_DELETE(this->qtImage);
+    this->qtImage = new QImage(w, h, desiredFormat);
+    SAFE_FREE(this->tempTexture);
+    releaseVulkanReadbackResources(this);
+    this->hasTexturePixels = false;
+    this->textureDataIsUpsideDown = false;
+    if (s_DebugLoggingEnabled) {
+        qInfo() << "[TextureDebug] setTextureSize window" << this->customId << "size" << w << "x" << h << "format"
+                << desiredFormat;
     }
 }
 
@@ -708,13 +1091,31 @@ void CustomWindow::setTexturePixels(const void* pixels, int byteCount, int w, in
     }
 
     if (this->qtImage == nullptr || this->qtImage->width() != w || this->qtImage->height() != h ||
-        this->tempTexture == nullptr) {
+        this->tempTexture == nullptr && this->textureUsesOpenGL) {
         this->setTextureSize(w, h);
     }
 
-    memcpy(this->tempTexture, pixels, expectedByteCount);
+    if (this->hasTexturePixels && this->updateQueued.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    int bytesPerLine = qtImage->bytesPerLine();
+    int height = qtImage->height();
+    int sourceBytesPerLine = w * 4;
+    uchar* startingBits = qtImage->bits();
+    const uchar* source = (const uchar*)pixels;
+    if (bytesPerLine == sourceBytesPerLine) {
+        memcpy(startingBits, source, expectedByteCount);
+    } else {
+        for (int i = 0; i < height; i++) {
+            memcpy(startingBits + i * bytesPerLine, source + i * sourceBytesPerLine, sourceBytesPerLine);
+        }
+    }
+
     this->textureUsesOpenGL = false;
+    this->textureUsesVulkan = false;
     this->hasTexturePixels = true;
+    this->textureDataIsUpsideDown = true;
     this->debugLoggedMissingTexture = false;
 
     if (s_DebugLoggingEnabled && (this->debugTextureUpdateCount < 3 || this->debugTextureUpdateCount % 120 == 0)) {
@@ -722,6 +1123,8 @@ void CustomWindow::setTexturePixels(const void* pixels, int byteCount, int w, in
                 << byteCount << samplePixelSummary((const unsigned char*)pixels, w, h);
     }
     this->debugTextureUpdateCount++;
+
+    requestWindowUpdate(this);
 }
 
 bool CustomWindow::copyTexture() {
@@ -732,12 +1135,19 @@ bool CustomWindow::copyTexture() {
         qWarning() << "WARNING: Tried to copyTexture() when window is closing.";
         return false;
     }
-    if (this->tempTexture == nullptr || this->qtImage == nullptr) {
+    if (this->qtImage == nullptr) {
         qWarning() << "WARNING: Tried to copyTexture() when texture is deleted.";
         return false;
     }
 
     if (this->textureUsesOpenGL) {
+        if (this->tempTexture == nullptr) {
+            this->tempTexture = malloc(this->qtImage->width() * this->qtImage->height() * 4);
+            if (this->tempTexture == nullptr) {
+                qWarning() << "[TextureDebug] Failed to allocate OpenGL temp texture buffer for window" << this->customId;
+                return false;
+            }
+        }
         glBindTexture(GL_TEXTURE_2D, this->glTextureId);
         glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, tempTexture);
         GLenum glError = glGetError();
@@ -753,16 +1163,23 @@ bool CustomWindow::copyTexture() {
         }
         this->debugLoggedMissingTexture = true;
         return false;
+    } else {
+        return true;
     }
 
     int bytesPerLine = qtImage->bytesPerLine();
     int height = qtImage->height();
+    int sourceBytesPerLine = this->qtImage->width() * 4;
     uchar* startingBits = qtImage->bits();
     uchar* source = (uchar*)tempTexture;
-    for (int i = 0; i < height; i++) {
-        int invertedY = (height - i - 1);
-        memcpy(startingBits + i * bytesPerLine, source + invertedY * bytesPerLine, bytesPerLine);
+    if (bytesPerLine == sourceBytesPerLine) {
+        memcpy(startingBits, source, bytesPerLine * height);
+    } else {
+        for (int i = 0; i < height; i++) {
+            memcpy(startingBits + i * bytesPerLine, source + i * sourceBytesPerLine, sourceBytesPerLine);
+        }
     }
+    this->textureDataIsUpsideDown = true;
 
     if (s_DebugLoggingEnabled && (this->debugCopyCount < 3 || this->debugCopyCount % 120 == 0)) {
         qInfo() << "[TextureDebug] copyTexture(" << (this->textureUsesOpenGL ? "OpenGL" : "CPU/Vulkan") << ") window"
@@ -952,6 +1369,7 @@ void CustomWindow::updateThings() {
 }
 
 void CustomWindow::paintEvent(QPaintEvent* paintEvent) {
+    this->updateQueued.store(false, std::memory_order_release);
     QPainter painter(this);
     if (!isVisible) {
         return;
@@ -966,6 +1384,7 @@ void CustomWindow::paintEvent(QPaintEvent* paintEvent) {
     this->debugLoggedNullImage = false;
 
     qreal scaling = waylandType == WaylandType::None ? this->devicePixelRatio() : 1;
+    QRect targetRect(this->cutoffX, this->cutoffY, this->targetWidth / scaling, this->targetHeight / scaling);
 
     if (s_DebugLoggingEnabled && (this->debugPaintCount < 3 || this->debugPaintCount % 120 == 0)) {
         qInfo() << "[PaintDebug] paintEvent window" << this->customId << "target" << this->targetWidth << "x"
@@ -976,8 +1395,15 @@ void CustomWindow::paintEvent(QPaintEvent* paintEvent) {
     }
     this->debugPaintCount++;
 
-    painter.drawImage(QRect(this->cutoffX, this->cutoffY, this->targetWidth / scaling, this->targetHeight / scaling),
-                      *this->qtImage, this->qtImage->rect());
+    if (this->textureDataIsUpsideDown) {
+        painter.save();
+        painter.translate(0, (2 * targetRect.y()) + targetRect.height());
+        painter.scale(1, -1);
+        painter.drawImage(targetRect, *this->qtImage, this->qtImage->rect());
+        painter.restore();
+    } else {
+        painter.drawImage(targetRect, *this->qtImage, this->qtImage->rect());
+    }
 }
 
 void CustomWindow::setIcon(QImage* image) {
@@ -1002,6 +1428,7 @@ void CustomWindow::closeEvent(QCloseEvent* closeEvent) {
 CustomWindow::~CustomWindow() {
     SAFE_DELETE(this->qtImage);
 #ifndef WITH_WINE
+    releaseVulkanReadbackResources(this);
     SAFE_FREE(this->tempTexture);
 #endif
 
@@ -1417,7 +1844,7 @@ extern "C" char* set_window_texture(HWND window,
 #ifdef WITH_WINE
                                     HWND texturePtr
 #else
-                                    GLuint texturePtr
+                                    uintptr_t texturePtr
 #endif
 ) {
     std::cerr << "set_window_texture(" << std::hex << window << std::dec << ", " << std::hex << texturePtr << std::dec
@@ -1431,12 +1858,14 @@ extern "C" char* set_window_texture(HWND window,
     customWindow->setTexture((ID3D11Resource*)texturePtr);
 #else
     if (s_RendererType == kUnityGfxRendererOpenGLCore) {
-        customWindow->setTexture(texturePtr);
+        customWindow->setTexture((GLuint)texturePtr);
+    } else if (s_RendererType == kUnityGfxRendererVulkan) {
+        customWindow->setVulkanTexture((void*)texturePtr);
     } else {
         customWindow->textureUsesOpenGL = false;
         qInfo() << "[TextureDebug] set_window_texture called while renderer is" << rendererTypeToString(s_RendererType)
                 << "for window" << customWindow->customId << "texturePtr" << texturePtr
-                << "- waiting for CPU/Vulkan upload path.";
+                << "- renderer not ready yet.";
     }
 #endif
     return createString("");
@@ -1684,9 +2113,26 @@ extern "C" WINAPI void arrange_windows(HWND* windows, int count) {
 static void UNITY_INTERFACE_API render(int eventID) {
     // std::cerr << "render(" << eventID << ")" << std::endl;
     customWindowMutex.lock();
+#ifndef WITH_WINE
+    UnityVulkanRecordingState vulkanRecordingState = {};
+    bool hasVulkanRecordingState = false;
+    if (s_RendererType == kUnityGfxRendererVulkan && eventID == kRenderEventVulkanCopy && s_GraphicsVulkan != nullptr) {
+        hasVulkanRecordingState =
+            s_GraphicsVulkan->CommandRecordingState(&vulkanRecordingState, kUnityVulkanGraphicsQueueAccess_DontCare);
+    }
+#endif
     for (auto customWindow : allCustomWindows) {
-        if (customWindow->copyTexture()) {
-            QMetaObject::invokeMethod(customWindow, qOverload<>(&QWidget::repaint), Qt::QueuedConnection);
+        if (customWindow->textureUsesOpenGL) {
+            if (customWindow->copyTexture()) {
+                requestWindowUpdate(customWindow);
+            }
+#ifndef WITH_WINE
+        } else if (customWindow->textureUsesVulkan && hasVulkanRecordingState) {
+            if (processCompletedVulkanReadback(customWindow, vulkanRecordingState.safeFrameNumber)) {
+                requestWindowUpdate(customWindow);
+            }
+            submitVulkanReadback(customWindow, vulkanRecordingState);
+#endif
         }
     }
     customWindowMutex.unlock();
@@ -1798,12 +2244,45 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
             return;
         }
         if (s_RendererType == kUnityGfxRendererVulkan) {
-            qInfo() << "[TextureDebug] Vulkan renderer detected, using CPU upload compatibility path for custom windows.";
+            s_GraphicsVulkan = s_UnityInterfaces->Get<IUnityGraphicsVulkan>();
+            if (s_GraphicsVulkan == nullptr) {
+                blockWithError("Unity Vulkan graphics interface is unavailable.");
+                return;
+            }
+
+            loadVulkanFunctions(s_GraphicsVulkan->Instance());
+            UnityVulkanPluginEventConfig eventConfig = {};
+            eventConfig.renderPassPrecondition = kUnityVulkanRenderPass_EnsureOutside;
+            eventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_DontCare;
+            eventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission |
+                                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
+            s_GraphicsVulkan->ConfigureEvent(kRenderEventVulkanCopy, &eventConfig);
+            qInfo() << "[TextureDebug] Vulkan renderer detected, using native Vulkan readback path for custom windows.";
         }
 #endif
         break;
     }
     case kUnityGfxDeviceEventShutdown: {
+#ifndef WITH_WINE
+        customWindowMutex.lock();
+        for (auto customWindow : allCustomWindows) {
+            releaseVulkanReadbackResources(customWindow);
+        }
+        customWindowMutex.unlock();
+        s_GraphicsVulkan = NULL;
+        s_vkGetPhysicalDeviceMemoryProperties = nullptr;
+        s_vkCreateBuffer = nullptr;
+        s_vkDestroyBuffer = nullptr;
+        s_vkGetBufferMemoryRequirements = nullptr;
+        s_vkAllocateMemory = nullptr;
+        s_vkFreeMemory = nullptr;
+        s_vkBindBufferMemory = nullptr;
+        s_vkMapMemory = nullptr;
+        s_vkUnmapMemory = nullptr;
+        s_vkInvalidateMappedMemoryRanges = nullptr;
+        s_vkCmdCopyImageToBuffer = nullptr;
+        s_vkCmdPipelineBarrier = nullptr;
+#endif
         s_RendererType = kUnityGfxRendererNull;
         break;
     }

--- a/multiwindow_unity.cpp
+++ b/multiwindow_unity.cpp
@@ -103,10 +103,57 @@ std::vector<CustomWindow*> allCustomWindows;
 QMutex customWindowMutex;
 std::vector<WId> storedWindowOrder;
 
+static IUnityInterfaces* s_UnityInterfaces = NULL;
+static IUnityGraphics* s_Graphics = NULL;
+static UnityGfxRenderer s_RendererType = kUnityGfxRendererNull;
+static bool s_DebugLoggingEnabled = false;
+
 xcb_connection_t* globalXcbConnection;
 Hyprctl* hyprctl = nullptr;
 
 std::string boolToStr(bool value) { return value ? "true" : "false"; }
+
+bool isTruthyEnvValue(QByteArray value) {
+    value = value.trimmed().toLower();
+    return !value.isEmpty() && value != "0" && value != "false" && value != "off" && value != "no";
+}
+
+const char* rendererTypeToString(UnityGfxRenderer rendererType) {
+    switch (rendererType) {
+    case kUnityGfxRendererOpenGLCore:
+        return "OpenGLCore";
+    case kUnityGfxRendererVulkan:
+        return "Vulkan";
+    case kUnityGfxRendererD3D11:
+        return "D3D11";
+    case kUnityGfxRendererNull:
+        return "Null";
+    default:
+        return "Other";
+    }
+}
+
+QString samplePixelSummary(const unsigned char* pixels, int width, int height) {
+    if (pixels == nullptr || width <= 0 || height <= 0) {
+        return "pixels=null";
+    }
+
+    auto sample = [&](int x, int y) {
+        x = std::max(0, std::min(x, width - 1));
+        y = std::max(0, std::min(y, height - 1));
+        int index = (y * width + x) * 4;
+        return QString("(%1,%2,%3,%4)")
+            .arg((int)pixels[index + 0])
+            .arg((int)pixels[index + 1])
+            .arg((int)pixels[index + 2])
+            .arg((int)pixels[index + 3]);
+    };
+
+    return QString("tl=%1 center=%2 br=%3")
+        .arg(sample(0, 0))
+        .arg(sample(width / 2, height / 2))
+        .arg(sample(width - 1, height - 1));
+}
 
 char* createString(const char* string) {
 #ifdef WITH_WINE
@@ -429,6 +476,8 @@ void createApplication() {
         return;
     }
     createdApplication = true;
+    s_DebugLoggingEnabled = isTruthyEnvValue(qgetenv("RD_DANCE_DEBUG"));
+    qInfo() << "RD_DANCE_DEBUG:" << s_DebugLoggingEnabled;
     needsX11Cutoff = doesDesktopNeedCutoff();
     checkForWayland();
 #ifdef WITH_WINE
@@ -626,12 +675,53 @@ bool CustomWindow::copyTexture() {
 
 #else
 
-void CustomWindow::setTexture(GLuint textureId) { this->glTextureId = textureId; }
+void CustomWindow::setTexture(GLuint textureId) {
+    this->glTextureId = textureId;
+    this->textureUsesOpenGL = true;
+    if (s_DebugLoggingEnabled) {
+        qInfo() << "[TextureDebug] setTexture(OpenGL) window" << this->customId << "textureId" << textureId;
+    }
+}
 
 void CustomWindow::setTextureSize(int w, int h) {
+    SAFE_DELETE(this->qtImage);
     this->qtImage = new QImage(w, h, QImage::Format_RGBA8888_Premultiplied);
     SAFE_FREE(this->tempTexture);
     tempTexture = malloc(w * h * 4);
+    this->hasTexturePixels = false;
+    if (s_DebugLoggingEnabled) {
+        qInfo() << "[TextureDebug] setTextureSize window" << this->customId << "size" << w << "x" << h;
+    }
+}
+
+void CustomWindow::setTexturePixels(const void* pixels, int byteCount, int w, int h) {
+    if (w <= 0 || h <= 0) {
+        qWarning() << "[TextureDebug] setTexturePixels ignored invalid size for window" << this->customId << w << h;
+        return;
+    }
+
+    int expectedByteCount = w * h * 4;
+    if (byteCount < expectedByteCount || pixels == nullptr) {
+        qWarning() << "[TextureDebug] setTexturePixels ignored invalid pixel payload for window" << this->customId
+                   << "bytes" << byteCount << "expected" << expectedByteCount << "pixelsNull" << (pixels == nullptr);
+        return;
+    }
+
+    if (this->qtImage == nullptr || this->qtImage->width() != w || this->qtImage->height() != h ||
+        this->tempTexture == nullptr) {
+        this->setTextureSize(w, h);
+    }
+
+    memcpy(this->tempTexture, pixels, expectedByteCount);
+    this->textureUsesOpenGL = false;
+    this->hasTexturePixels = true;
+    this->debugLoggedMissingTexture = false;
+
+    if (s_DebugLoggingEnabled && (this->debugTextureUpdateCount < 3 || this->debugTextureUpdateCount % 120 == 0)) {
+        qInfo() << "[TextureDebug] setTexturePixels window" << this->customId << "size" << w << "x" << h << "bytes"
+                << byteCount << samplePixelSummary((const unsigned char*)pixels, w, h);
+    }
+    this->debugTextureUpdateCount++;
 }
 
 bool CustomWindow::copyTexture() {
@@ -647,8 +737,23 @@ bool CustomWindow::copyTexture() {
         return false;
     }
 
-    glBindTexture(GL_TEXTURE_2D, this->glTextureId);
-    glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, tempTexture);
+    if (this->textureUsesOpenGL) {
+        glBindTexture(GL_TEXTURE_2D, this->glTextureId);
+        glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, tempTexture);
+        GLenum glError = glGetError();
+        if (glError != GL_NO_ERROR) {
+            qWarning() << "[TextureDebug] glGetTexImage error for window" << this->customId << "error" << glError;
+        } else if (s_DebugLoggingEnabled && (this->debugCopyCount < 3 || this->debugCopyCount % 120 == 0)) {
+            qInfo() << "[TextureDebug] copyTexture(OpenGL) window" << this->customId << "textureId" << this->glTextureId
+                    << "size" << this->qtImage->width() << "x" << this->qtImage->height();
+        }
+    } else if (!this->hasTexturePixels) {
+        if (!this->debugLoggedMissingTexture || s_DebugLoggingEnabled) {
+            qWarning() << "[TextureDebug] copyTexture waiting for CPU/Vulkan pixels for window" << this->customId;
+        }
+        this->debugLoggedMissingTexture = true;
+        return false;
+    }
 
     int bytesPerLine = qtImage->bytesPerLine();
     int height = qtImage->height();
@@ -658,6 +763,14 @@ bool CustomWindow::copyTexture() {
         int invertedY = (height - i - 1);
         memcpy(startingBits + i * bytesPerLine, source + invertedY * bytesPerLine, bytesPerLine);
     }
+
+    if (s_DebugLoggingEnabled && (this->debugCopyCount < 3 || this->debugCopyCount % 120 == 0)) {
+        qInfo() << "[TextureDebug] copyTexture(" << (this->textureUsesOpenGL ? "OpenGL" : "CPU/Vulkan") << ") window"
+                << this->customId << "image" << this->qtImage->width() << "x" << this->qtImage->height()
+                << samplePixelSummary((const unsigned char*)this->qtImage->constBits(), this->qtImage->width(),
+                                      this->qtImage->height());
+    }
+    this->debugCopyCount++;
 
     return true;
 }
@@ -844,10 +957,24 @@ void CustomWindow::paintEvent(QPaintEvent* paintEvent) {
         return;
     }
     if (this->qtImage == nullptr) {
+        if (s_DebugLoggingEnabled && !this->debugLoggedNullImage) {
+            qWarning() << "[PaintDebug] paintEvent skipped because qtImage is null for window" << this->customId;
+        }
+        this->debugLoggedNullImage = true;
         return;
     }
+    this->debugLoggedNullImage = false;
 
     qreal scaling = waylandType == WaylandType::None ? this->devicePixelRatio() : 1;
+
+    if (s_DebugLoggingEnabled && (this->debugPaintCount < 3 || this->debugPaintCount % 120 == 0)) {
+        qInfo() << "[PaintDebug] paintEvent window" << this->customId << "target" << this->targetWidth << "x"
+                << this->targetHeight << "image" << this->qtImage->width() << "x" << this->qtImage->height()
+                << "opacity" << this->targetOpacity
+                << samplePixelSummary((const unsigned char*)this->qtImage->constBits(), this->qtImage->width(),
+                                      this->qtImage->height());
+    }
+    this->debugPaintCount++;
 
     painter.drawImage(QRect(this->cutoffX, this->cutoffY, this->targetWidth / scaling, this->targetHeight / scaling),
                       *this->qtImage, this->qtImage->rect());
@@ -1303,7 +1430,14 @@ extern "C" char* set_window_texture(HWND window,
 #ifdef WITH_WINE
     customWindow->setTexture((ID3D11Resource*)texturePtr);
 #else
-    customWindow->setTexture(texturePtr);
+    if (s_RendererType == kUnityGfxRendererOpenGLCore) {
+        customWindow->setTexture(texturePtr);
+    } else {
+        customWindow->textureUsesOpenGL = false;
+        qInfo() << "[TextureDebug] set_window_texture called while renderer is" << rendererTypeToString(s_RendererType)
+                << "for window" << customWindow->customId << "texturePtr" << texturePtr
+                << "- waiting for CPU/Vulkan upload path.";
+    }
 #endif
     return createString("");
 }
@@ -1312,6 +1446,17 @@ extern "C" char* set_window_texture(HWND window,
 extern "C" void set_window_texture_size(HWND window, int w, int h) {
     CustomWindow* customWindow = (CustomWindow*)window;
     customWindow->setTextureSize(w, h);
+}
+
+extern "C" void set_window_texture_pixels(HWND window, const unsigned char* pixels, int byteCount, int w, int h) {
+    if (window == MAIN_WINDOW) {
+        return;
+    }
+
+    CustomWindow* customWindow = (CustomWindow*)window;
+    customWindowMutex.lock();
+    customWindow->setTexturePixels(pixels, byteCount, w, h);
+    customWindowMutex.unlock();
 }
 #endif
 
@@ -1632,14 +1777,11 @@ extern "C" const char* get_info() {
 }
 #endif
 
-static IUnityInterfaces* s_UnityInterfaces = NULL;
-static IUnityGraphics* s_Graphics = NULL;
-static UnityGfxRenderer s_RendererType = kUnityGfxRendererNull;
-
 static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType eventType) {
     switch (eventType) {
     case kUnityGfxDeviceEventInitialize: {
         s_RendererType = s_Graphics->GetRenderer();
+        qInfo() << "Unity graphics renderer:" << rendererTypeToString(s_RendererType);
 #ifdef WITH_WINE
         if (s_RendererType != kUnityGfxRendererD3D11) {
             blockWithError("Only D3D11 is supported.");
@@ -1651,9 +1793,12 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
         }
         app->device = d3d->GetDevice();
 #else
-        if (s_RendererType != kUnityGfxRendererOpenGLCore) {
-            blockWithError("Only OpenGL Core is supported.");
+        if (s_RendererType != kUnityGfxRendererOpenGLCore && s_RendererType != kUnityGfxRendererVulkan) {
+            blockWithError("Only OpenGL Core and Vulkan are supported.");
             return;
+        }
+        if (s_RendererType == kUnityGfxRendererVulkan) {
+            qInfo() << "[TextureDebug] Vulkan renderer detected, using CPU upload compatibility path for custom windows.";
         }
 #endif
         break;

--- a/multiwindow_unity.hpp
+++ b/multiwindow_unity.hpp
@@ -20,6 +20,12 @@ class CustomWindow : public QWidget {
     int cutoffX = 0;
     int cutoffY = 0;
 
+    int debugTextureUpdateCount = 0;
+    int debugCopyCount = 0;
+    int debugPaintCount = 0;
+    bool debugLoggedMissingTexture = false;
+    bool debugLoggedNullImage = false;
+
 #ifdef WITH_WINE
     ID3D11Resource* resource = nullptr;
     ID3D11Texture2D* texture = nullptr;
@@ -32,6 +38,8 @@ class CustomWindow : public QWidget {
 #else
     GLuint glTextureId = -1;
     void* tempTexture = nullptr;
+    bool textureUsesOpenGL = false;
+    bool hasTexturePixels = false;
 #endif
 
     QImage* qtImage = nullptr;
@@ -46,6 +54,7 @@ class CustomWindow : public QWidget {
 #else
     void setTexture(GLuint textureId);
     void setTextureSize(int w, int h);
+    void setTexturePixels(const void* pixels, int byteCount, int w, int h);
 #endif
     bool copyTexture();
 

--- a/multiwindow_unity.hpp
+++ b/multiwindow_unity.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+#include <cstddef>
+
 class CustomWindow : public QWidget {
   public:
     int customId;
@@ -25,6 +28,8 @@ class CustomWindow : public QWidget {
     int debugPaintCount = 0;
     bool debugLoggedMissingTexture = false;
     bool debugLoggedNullImage = false;
+    bool textureDataIsUpsideDown = false;
+    std::atomic_bool updateQueued = false;
 
 #ifdef WITH_WINE
     ID3D11Resource* resource = nullptr;
@@ -39,7 +44,19 @@ class CustomWindow : public QWidget {
     GLuint glTextureId = -1;
     void* tempTexture = nullptr;
     bool textureUsesOpenGL = false;
+    bool textureUsesVulkan = false;
     bool hasTexturePixels = false;
+    void* unityVulkanTexture = nullptr;
+    void* vulkanReadbackBuffer = nullptr;
+    void* vulkanReadbackMemory = nullptr;
+    void* vulkanReadbackMapped = nullptr;
+    size_t vulkanReadbackSize = 0;
+    bool vulkanReadbackHostCoherent = false;
+    int vulkanReadbackWidth = 0;
+    int vulkanReadbackHeight = 0;
+    bool vulkanReadbackSwapRedBlue = false;
+    unsigned long long vulkanReadbackSubmittedFrame = 0;
+    bool vulkanReadbackPending = false;
 #endif
 
     QImage* qtImage = nullptr;
@@ -53,6 +70,7 @@ class CustomWindow : public QWidget {
     void setTexture(ID3D11Resource* resource);
 #else
     void setTexture(GLuint textureId);
+    void setVulkanTexture(void* texturePtr);
     void setTextureSize(int w, int h);
     void setTexturePixels(const void* pixels, int byteCount, int w, int h);
 #endif

--- a/unity/IUnityGraphicsVulkan.h
+++ b/unity/IUnityGraphicsVulkan.h
@@ -1,0 +1,336 @@
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+//
+// Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+//
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.Please review the license for details on these and other terms and conditions.
+
+#pragma once
+#include "IUnityInterface.h"
+#include <stdbool.h>
+
+#ifndef UNITY_VULKAN_HEADER
+#define UNITY_VULKAN_HEADER <vulkan/vulkan.h>
+#endif
+
+#include UNITY_VULKAN_HEADER
+
+typedef struct UnityVulkanInstance
+{
+    VkPipelineCache pipelineCache; // Unity's pipeline cache is serialized to disk
+    VkInstance instance;
+    VkPhysicalDevice physicalDevice;
+    VkDevice device;
+    VkQueue graphicsQueue;
+    PFN_vkGetInstanceProcAddr getInstanceProcAddr; // vkGetInstanceProcAddr of the Vulkan loader, same as the one passed to UnityVulkanInitCallback
+    unsigned int queueFamilyIndex;
+
+    void* reserved[8];
+}UnityVulkanInstance;
+
+typedef struct UnityVulkanMemory
+{
+    VkDeviceMemory memory;        // Vulkan memory handle
+    VkDeviceSize offset;          // offset within memory
+    VkDeviceSize size;            // size in bytes, may be less than the total size of memory;
+    void* mapped;                 // pointer to mapped memory block, NULL if not mappable, offset is already applied, remaining block still has at least the given size.
+    VkMemoryPropertyFlags flags;  // Vulkan memory properties
+    unsigned int memoryTypeIndex; // index into VkPhysicalDeviceMemoryProperties::memoryTypes
+
+    void* reserved[4];
+}UnityVulkanMemory;
+
+typedef enum UnityVulkanResourceAccessMode
+{
+    // Does not imply any pipeline barriers, should only be used to query resource attributes
+    kUnityVulkanResourceAccess_ObserveOnly,
+
+    // Handles layout transition and barriers
+    kUnityVulkanResourceAccess_PipelineBarrier,
+
+    // Recreates the backing resource (VkBuffer/VkImage) but keeps the previous one alive if it's in use
+    kUnityVulkanResourceAccess_Recreate,
+}UnityVulkanResourceAccessMode;
+
+typedef struct UnityVulkanImage
+{
+    UnityVulkanMemory memory;   // memory that backs the image
+    VkImage image;              // Vulkan image handle
+    VkImageLayout layout;       // current layout, may change resource access
+    VkImageAspectFlags aspect;
+    VkImageUsageFlags usage;
+    VkFormat format;
+    VkExtent3D extent;
+    VkImageTiling tiling;
+    VkImageType type;
+    VkSampleCountFlagBits samples;
+    int layers;
+    int mipCount;
+
+    void* reserved[4];
+}UnityVulkanImage;
+
+typedef struct UnityVulkanBuffer
+{
+    UnityVulkanMemory memory;   // memory that backs the buffer
+    VkBuffer buffer;            // Vulkan buffer handle
+    size_t sizeInBytes;         // size of the buffer in bytes, may be less than memory size
+    VkBufferUsageFlags usage;
+
+    void* reserved[4];
+}UnityVulkanBuffer;
+
+typedef struct UnityVulkanRecordingState
+{
+    VkCommandBuffer commandBuffer;              // Vulkan command buffer that is currently recorded by Unity
+    VkCommandBufferLevel commandBufferLevel;
+    VkRenderPass renderPass;                    // Current render pass, a compatible one or VK_NULL_HANDLE
+    VkFramebuffer framebuffer;                  // Current framebuffer or VK_NULL_HANDLE
+    int subPassIndex;                           // index of the current sub pass, -1 if not inside a render pass
+
+    // Resource life-time tracking counters, only relevant for resources allocated by the plugin
+    unsigned long long currentFrameNumber;      // can be used to track lifetime of own resources
+    unsigned long long safeFrameNumber;         // all resources that were used in this frame (or before) are safe to be released
+
+    void* reserved[4];
+}UnityVulkanRecordingState;
+
+typedef enum UnityVulkanEventRenderPassPreCondition
+{
+    // Don't care about the state on Unity's current command buffer
+    // This is the default precondition
+    kUnityVulkanRenderPass_DontCare,
+
+    // Make sure that there is currently RenderPass in progress.
+    // There are no guarantees about the currently bound descriptor sets, vertex buffers, index buffers and pipeline objects
+    // Unity does however set dynamic pipeline set VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR based on the current settings
+    // If used in combination with the SRP RenderPass API the resuls is undefined
+    kUnityVulkanRenderPass_EnsureInside,
+
+    // Make sure that there is currently no RenderPass in progress.
+    // This allows e.g. resource uploads.
+    // Ends the current render pass (and resumes it afterwards if needed)
+    // If used in combination with the SRP RenderPass API the resuls is undefined.
+    kUnityVulkanRenderPass_EnsureOutside
+}UnityVulkanEventRenderPassPreCondition;
+
+typedef enum UnityVulkanGraphicsQueueAccess
+{
+    // No queue acccess, no work must be submitted to UnityVulkanInstance::graphicsQueue from the plugin event callback
+    kUnityVulkanGraphicsQueueAccess_DontCare,
+
+    // Make sure that Unity worker threads don't access the Vulkan graphics queue
+    // This disables access to the current Unity command buffer
+    kUnityVulkanGraphicsQueueAccess_Allow,
+}UnityVulkanGraphicsQueueAccess;
+
+typedef enum UnityVulkanEventConfigFlagBits
+{
+    kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission = (1 << 0), // default: set
+    kUnityVulkanEventConfigFlag_FlushCommandBuffers = (1 << 1),           // submit existing command buffers, default: not set
+    kUnityVulkanEventConfigFlag_SyncWorkerThreads = (1 << 2),             // wait for worker threads to finish, default: not set
+    kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState = (1 << 3),   // should be set when descriptor set bindings, vertex buffer bindings, etc are changed (default: set)
+}UnityVulkanEventConfigFlagBits;
+
+typedef struct UnityVulkanPluginEventConfig
+{
+    UnityVulkanEventRenderPassPreCondition renderPassPrecondition;
+    UnityVulkanGraphicsQueueAccess graphicsQueueAccess;
+    uint32_t flags;
+}UnityVulkanPluginEventConfig;
+
+// Constant that can be used to reference the whole image
+const VkImageSubresource* const UnityVulkanWholeImage = NULL;
+
+// callback function, see InterceptInitialization
+typedef PFN_vkGetInstanceProcAddr(UNITY_INTERFACE_API * UnityVulkanInitCallback)(PFN_vkGetInstanceProcAddr getInstanceProcAddr, void* userdata);
+
+typedef enum UnityVulkanSwapchainMode
+{
+    kUnityVulkanSwapchainMode_Default,
+    kUnityVulkanSwapchainMode_Offscreen
+}UnityVulkanSwapchainMode;
+
+typedef struct UnityVulkanSwapchainConfiguration
+{
+    UnityVulkanSwapchainMode mode;
+}UnityVulkanSwapchainConfiguration;
+
+enum
+{
+    kUnityVulkanInitCallbackMaxPriority = 0x7FFFFFFF
+};
+
+UNITY_DECLARE_INTERFACE(IUnityGraphicsVulkanV2)
+{
+    // Vulkan API hooks
+    //
+    // Must be called before kUnityGfxDeviceEventInitialize (preload plugin)
+    // Unity will call 'func' when initializing the Vulkan API
+    // The 'getInstanceProcAddr' passed to the callback is the function pointer from the Vulkan Loader
+    // The function pointer returned from UnityVulkanInitCallback may be a different implementation
+    // This allows intercepting all Vulkan API calls
+    // This function is equivalent to calling `AddInterceptInitialization` with a priority of `kUnityVulkanInitCallbackMaxPriority`
+    //
+    // Most rules/restrictions for implementing a Vulkan layer apply
+    // Returns true on success, false on failure (typically because it is used too late)
+    bool(UNITY_INTERFACE_API * InterceptInitialization)(UnityVulkanInitCallback func, void* userdata);
+
+    // Intercept Vulkan API function of the given name with the given function
+    // In contrast to InterceptInitialization this interface can be used at any time
+    // The user must handle all synchronization
+    // Generally this cannot be used to wrap Vulkan object because there might because there may already be non-wrapped instances
+    // returns the previous function pointer
+    PFN_vkVoidFunction(UNITY_INTERFACE_API * InterceptVulkanAPI)(const char* name, PFN_vkVoidFunction func);
+
+    // Change the precondition for a specific user-defined event
+    // Should be called during initialization
+    void(UNITY_INTERFACE_API * ConfigureEvent)(int eventID, const UnityVulkanPluginEventConfig * pluginEventConfig);
+
+    // Access the Vulkan instance and render queue created by Unity
+    // UnityVulkanInstance does not change between kUnityGfxDeviceEventInitialize and kUnityGfxDeviceEventShutdown
+    UnityVulkanInstance(UNITY_INTERFACE_API * Instance)();
+
+    // Access the current command buffer
+    //
+    // outCommandRecordingState is invalidated by any resource access calls.
+    // queueAccess must be kUnityVulkanGraphicsQueueAccess_Allow when called from from a AccessQueue callback or from a event that is configured for queue access.
+    // Otherwise queueAccess must be kUnityVulkanGraphicsQueueAccess_DontCare.
+    bool(UNITY_INTERFACE_API * CommandRecordingState)(UnityVulkanRecordingState * outCommandRecordingState, UnityVulkanGraphicsQueueAccess queueAccess);
+
+    // Resource access
+    //
+    // Using the following resource query APIs will mark the resources as used for the current frame.
+    // Pipeline barriers will be inserted when needed.
+    //
+    // Resource access APIs may record commands, so the current UnityVulkanRecordingState is invalidated
+    // Must not be called from event callbacks configured for queue access (UnityVulkanGraphicsQueueAccess_Allow)
+    // or from a AccessQueue callback of an event
+    bool(UNITY_INTERFACE_API * AccessTexture)(void* nativeTexture, const VkImageSubresource * subResource, VkImageLayout layout,
+        VkPipelineStageFlags pipelineStageFlags, VkAccessFlags accessFlags, UnityVulkanResourceAccessMode accessMode, UnityVulkanImage * outImage);
+
+    bool(UNITY_INTERFACE_API * AccessRenderBufferTexture)(UnityRenderBuffer nativeRenderBuffer, const VkImageSubresource * subResource, VkImageLayout layout,
+        VkPipelineStageFlags pipelineStageFlags, VkAccessFlags accessFlags, UnityVulkanResourceAccessMode accessMode, UnityVulkanImage * outImage);
+
+    bool(UNITY_INTERFACE_API * AccessRenderBufferResolveTexture)(UnityRenderBuffer nativeRenderBuffer, const VkImageSubresource * subResource, VkImageLayout layout,
+        VkPipelineStageFlags pipelineStageFlags, VkAccessFlags accessFlags, UnityVulkanResourceAccessMode accessMode, UnityVulkanImage * outImage);
+
+    bool(UNITY_INTERFACE_API * AccessBuffer)(void* nativeBuffer, VkPipelineStageFlags pipelineStageFlags, VkAccessFlags accessFlags, UnityVulkanResourceAccessMode accessMode, UnityVulkanBuffer * outBuffer);
+
+    // Control current state of render pass
+    //
+    // Must not be called from event callbacks configured for queue access (UnityVulkanGraphicsQueueAccess_Allow, UnityVulkanGraphicsQueueAccess_FlushAndAllow)
+    // or from a AccessQueue callback of an event
+    // See kUnityVulkanRenderPass_EnsureInside, kUnityVulkanRenderPass_EnsureOutside
+    void(UNITY_INTERFACE_API * EnsureOutsideRenderPass)();
+    void(UNITY_INTERFACE_API * EnsureInsideRenderPass)();
+
+    // Allow command buffer submission to the the Vulkan graphics queue from the given UnityRenderingEventAndData callback.
+    // This is an alternative to using ConfigureEvent with kUnityVulkanGraphicsQueueAccess_Allow.
+    //
+    // eventId and userdata are passed to the callback
+    // This may or may not be called synchronously or from the submission thread.
+    // If flush is true then all Unity command buffers of this frame are submitted before UnityQueueAccessCallback
+    void(UNITY_INTERFACE_API * AccessQueue)(UnityRenderingEventAndData, int eventId, void* userData, bool flush);
+
+    // Configure swapchains that are created by Unity.
+    // Must be called before kUnityGfxDeviceEventInitialize (preload plugin)
+    bool(UNITY_INTERFACE_API * ConfigureSwapchain)(const UnityVulkanSwapchainConfiguration * swapChainConfig);
+
+    // see AccessTexture
+    // Accepts UnityTextureID (UnityRenderingExtTextureUpdateParamsV2::textureID, UnityRenderingExtCustomBlitParams::source)
+    bool(UNITY_INTERFACE_API * AccessTextureByID)(UnityTextureID textureID, const VkImageSubresource * subResource, VkImageLayout layout,
+        VkPipelineStageFlags pipelineStageFlags, VkAccessFlags accessFlags, UnityVulkanResourceAccessMode accessMode, UnityVulkanImage * outImage);
+
+    // Vulkan API hooks
+    //
+    // Must be called before kUnityGfxDeviceEventInitialize (preload plugin)
+    // Unity will call 'func' when initializing the Vulkan API
+    // The 'getInstanceProcAddr' passed to the callback is the function pointer from the Vulkan Loader
+    // The function pointer returned from UnityVulkanInitCallback may be a different implementation
+    // This allows intercepting all Vulkan API calls
+    // The priority is used to sort multiple callbacks such that the highest priority will be called last
+    //   with the original Vulkan loader implementation of vkGetInstanceProcAddress passed in as 'getInstanceProcAddr'.
+    // A priority value of `kUnityVulkanInitCallbackMaxPriority` is used to force a callback to be called immediately before
+    //   the original Vulkan loader implementation of `vkGetInstanceProcAddress`.  Only one callback can be registered with a
+    //   priority of `kUnityVulkanInitCallbackMaxPriority`, if one already exists it will be replaced.
+    // Passing a priority value of `kUnityVulkanInitCallbackMaxPriority` is equivalent to calling the `InterceptInitialization` method.
+    //
+    // Most rules/restrictions for implementing a Vulkan layer apply
+    // Returns true on success, false on failure (typically because it is used too late)
+    bool(UNITY_INTERFACE_API * AddInterceptInitialization)(UnityVulkanInitCallback func, void* userdata, int32_t priority);
+    // Remove vulkan intercept initialization callback.
+
+    // Removal will not take effect until the next time vulkan is initialized.
+    bool(UNITY_INTERFACE_API * RemoveInterceptInitialization)(UnityVulkanInitCallback func);
+};
+UNITY_REGISTER_INTERFACE_GUID(0x329334C09DCA4787ULL, 0xB347DD92A0097FFCULL, IUnityGraphicsVulkanV2)
+
+UNITY_DECLARE_INTERFACE(IUnityGraphicsVulkan)
+{
+    // Vulkan API hooks
+    //
+    // Must be called before kUnityGfxDeviceEventInitialize (preload plugin)
+    // Unity will call 'func' when initializing the Vulkan API
+    // The 'getInstanceProcAddr' passed to the callback is the function pointer from the Vulkan Loader
+    // The function pointer returned from UnityVulkanInitCallback may be a different implementation
+    // This allows intercepting all Vulkan API calls
+    //
+    // Most rules/restrictions for implementing a Vulkan layer apply
+    // Returns true on success, false on failure (typically because it is used too late)
+    bool(UNITY_INTERFACE_API * InterceptInitialization)(UnityVulkanInitCallback func, void* userdata);
+    // Intercept Vulkan API function of the given name with the given function
+    // In contrast to InterceptInitialization this interface can be used at any time
+    // The user must handle all synchronization
+    // Generally this cannot be used to wrap Vulkan object because there might because there may already be non-wrapped instances
+    // returns the previous function pointer
+    PFN_vkVoidFunction(UNITY_INTERFACE_API * InterceptVulkanAPI)(const char* name, PFN_vkVoidFunction func);
+    // Change the precondition for a specific user-defined event
+    // Should be called during initialization
+    void(UNITY_INTERFACE_API * ConfigureEvent)(int eventID, const UnityVulkanPluginEventConfig * pluginEventConfig);
+    // Access the Vulkan instance and render queue created by Unity
+    // UnityVulkanInstance does not change between kUnityGfxDeviceEventInitialize and kUnityGfxDeviceEventShutdown
+    UnityVulkanInstance(UNITY_INTERFACE_API * Instance)();
+    // Access the current command buffer
+    //
+    // outCommandRecordingState is invalidated by any resource access calls.
+    // queueAccess must be kUnityVulkanGraphicsQueueAccess_Allow when called from from a AccessQueue callback or from a event that is configured for queue access.
+    // Otherwise queueAccess must be kUnityVulkanGraphicsQueueAccess_DontCare.
+    bool(UNITY_INTERFACE_API * CommandRecordingState)(UnityVulkanRecordingState * outCommandRecordingState, UnityVulkanGraphicsQueueAccess queueAccess);
+    // Resource access
+    //
+    // Using the following resource query APIs will mark the resources as used for the current frame.
+    // Pipeline barriers will be inserted when needed.
+    //
+    // Resource access APIs may record commands, so the current UnityVulkanRecordingState is invalidated
+    // Must not be called from event callbacks configured for queue access (UnityVulkanGraphicsQueueAccess_Allow)
+    // or from a AccessQueue callback of an event
+    bool(UNITY_INTERFACE_API * AccessTexture)(void* nativeTexture, const VkImageSubresource * subResource, VkImageLayout layout,
+        VkPipelineStageFlags pipelineStageFlags, VkAccessFlags accessFlags, UnityVulkanResourceAccessMode accessMode, UnityVulkanImage * outImage);
+    bool(UNITY_INTERFACE_API * AccessRenderBufferTexture)(UnityRenderBuffer nativeRenderBuffer, const VkImageSubresource * subResource, VkImageLayout layout,
+        VkPipelineStageFlags pipelineStageFlags, VkAccessFlags accessFlags, UnityVulkanResourceAccessMode accessMode, UnityVulkanImage * outImage);
+    bool(UNITY_INTERFACE_API * AccessRenderBufferResolveTexture)(UnityRenderBuffer nativeRenderBuffer, const VkImageSubresource * subResource, VkImageLayout layout,
+        VkPipelineStageFlags pipelineStageFlags, VkAccessFlags accessFlags, UnityVulkanResourceAccessMode accessMode, UnityVulkanImage * outImage);
+    bool(UNITY_INTERFACE_API * AccessBuffer)(void* nativeBuffer, VkPipelineStageFlags pipelineStageFlags, VkAccessFlags accessFlags, UnityVulkanResourceAccessMode accessMode, UnityVulkanBuffer * outBuffer);
+    // Control current state of render pass
+    //
+    // Must not be called from event callbacks configured for queue access (UnityVulkanGraphicsQueueAccess_Allow, UnityVulkanGraphicsQueueAccess_FlushAndAllow)
+    // or from a AccessQueue callback of an event
+    // See kUnityVulkanRenderPass_EnsureInside, kUnityVulkanRenderPass_EnsureOutside
+    void(UNITY_INTERFACE_API * EnsureOutsideRenderPass)();
+    void(UNITY_INTERFACE_API * EnsureInsideRenderPass)();
+    // Allow command buffer submission to the the Vulkan graphics queue from the given UnityRenderingEventAndData callback.
+    // This is an alternative to using ConfigureEvent with kUnityVulkanGraphicsQueueAccess_Allow.
+    //
+    // eventId and userdata are passed to the callback
+    // This may or may not be called synchronously or from the submission thread.
+    // If flush is true then all Unity command buffers of this frame are submitted before UnityQueueAccessCallback
+    void(UNITY_INTERFACE_API * AccessQueue)(UnityRenderingEventAndData, int eventId, void* userData, bool flush);
+    // Configure swapchains that are created by Unity.
+    // Must be called before kUnityGfxDeviceEventInitialize (preload plugin)
+    bool(UNITY_INTERFACE_API * ConfigureSwapchain)(const UnityVulkanSwapchainConfiguration * swapChainConfig);
+    // see AccessTexture
+    // Accepts UnityTextureID (UnityRenderingExtTextureUpdateParamsV2::textureID, UnityRenderingExtCustomBlitParams::source)
+    bool(UNITY_INTERFACE_API * AccessTextureByID)(UnityTextureID textureID, const VkImageSubresource * subResource, VkImageLayout layout,
+        VkPipelineStageFlags pipelineStageFlags, VkAccessFlags accessFlags, UnityVulkanResourceAccessMode accessMode, UnityVulkanImage * outImage);
+};
+UNITY_REGISTER_INTERFACE_GUID(0x95355348d4ef4e11ULL, 0x9789313dfcffcc87ULL, IUnityGraphicsVulkan)


### PR DESCRIPTION
This PR makes the plugin work under Vulkan mode

Plugin now works when Unity is launched with -force-vulkan flag

Current status & known trade-offs
Functionality: Vulkan mode window movement is now working.
Performance: Current runtime efficiency needs improvement. Frame rate / response time may not be as smooth as when running in OpenGL mode.

Tested on KDE Plasma 6.6.4 Wayland — no issues observed

*Parts of this PR were written with the assistance of AI